### PR TITLE
Various UX improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,42 +80,51 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -283,7 +292,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -388,18 +397,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "9b802d85aaf3a1cdb02b224ba472ebdea62014fccfcb269b95a4d76443b5ee5a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -481,6 +490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "colors-transform"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,21 +509,6 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concolor-override"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1083,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "fltk"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4670a59cce3acb71ee49bbda4d424e5856ddb496f35e29ffe3c9f387f9d2dd6c"
+checksum = "80e46e853afdd96fcf53086320813a532e17298b80a7abb94540c75518219eba"
 dependencies = [
  "bitflags 2.1.0",
  "crossbeam-channel",
@@ -1096,11 +1096,12 @@ dependencies = [
 
 [[package]]
 name = "fltk-sys"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9df2eb7a127947d0176a7bff2c7ea8d4db91cf674b38bbc6aae0b4e0e103c1f"
+checksum = "7292a228e1e0f367389106767940e92461053aa97d44706ff621d9a3cbdb001b"
 dependencies = [
  "cmake",
+ "cty",
 ]
 
 [[package]]
@@ -1149,7 +1150,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1674,7 +1675,7 @@ checksum = "8842972f23939443013dfd3720f46772b743e86f1a81d120d4b6fb090f87de1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2504,14 +2505,14 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -2954,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3029,7 +3030,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3344,7 +3345,7 @@ version = "0.1.0"
 dependencies = [
  "atomic_float",
  "bytemuck",
- "clap 4.2.1",
+ "clap 4.2.2",
  "colors-transform",
  "confy",
  "crossbeam-channel",
@@ -3531,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579cc485bd5ce5bfa0d738e4921dd0b956eca9800be1fd2e5257ebe95bc4617e"
+checksum = "b692165700260bbd40fbc5ff23766c03e339fbaca907aeea5cb77bf0a553ca83"
 dependencies = [
  "core-foundation",
  "dirs 4.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,15 +952,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs_io"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
-dependencies = [
- "encoding_rs",
-]
-
-[[package]]
 name = "enum_dispatch"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "kdmapi"
 version = "0.1.0"
-source = "git+https://github.com/arduano/kdmapi.git#9329cfc57e808a5e05d537d1e4ae1bd219416292"
+source = "git+https://github.com/arduano/kdmapi.git?rev=9329cfc#9329cfc57e808a5e05d537d1e4ae1bd219416292"
 dependencies = [
  "lazy_static",
  "libloading",
@@ -1625,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "midi-toolkit-rs"
 version = "0.1.0"
-source = "git+https://github.com/arduano/midi-toolkit-rs#cff22acf3a3113ac9f1f05b0fb8f9cd30f3f95ac"
+source = "git+https://github.com/arduano/midi-toolkit-rs?rev=4482d61#4482d61eebe98442e3539ba0dc8bf39e0565669c"
 dependencies = [
  "crossbeam-channel",
  "gen-iter 0.2.1",
@@ -1638,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "midi-toolkit-rs-derive"
 version = "0.1.0"
-source = "git+https://github.com/arduano/midi-toolkit-rs#cff22acf3a3113ac9f1f05b0fb8f9cd30f3f95ac"
+source = "git+https://github.com/arduano/midi-toolkit-rs?rev=4482d61#4482d61eebe98442e3539ba0dc8bf39e0565669c"
 dependencies = [
  "convert_case",
  "num-traits",
@@ -3919,7 +3910,7 @@ checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 [[package]]
 name = "xsynth-core"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
+source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
 dependencies = [
  "atomic_refcell",
  "biquad",
@@ -3938,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "xsynth-realtime"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
+source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
 dependencies = [
  "atomic_refcell",
  "bytemuck",
@@ -3956,10 +3947,8 @@ dependencies = [
 [[package]]
 name = "xsynth-soundfonts"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
+source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
 dependencies = [
- "encoding_rs",
- "encoding_rs_io",
  "lazy-regex",
  "regex-bnf",
  "simdeez 1.0.8 (git+https://github.com/arduano/simdeez.git?rev=86f8bf9)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_pub"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cede240e13256fcfbade77d11b9bbe68c2d002856279f92d1d64c3c583c58f21"
+dependencies = [
+ "xxhash-rust",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "midi-toolkit-rs"
 version = "0.1.0"
-source = "git+https://github.com/arduano/midi-toolkit-rs?rev=4482d61#4482d61eebe98442e3539ba0dc8bf39e0565669c"
+source = "git+https://github.com/arduano/midi-toolkit-rs?rev=cff22ac#cff22acf3a3113ac9f1f05b0fb8f9cd30f3f95ac"
 dependencies = [
  "crossbeam-channel",
  "gen-iter 0.2.1",
@@ -1629,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "midi-toolkit-rs-derive"
 version = "0.1.0"
-source = "git+https://github.com/arduano/midi-toolkit-rs?rev=4482d61#4482d61eebe98442e3539ba0dc8bf39e0565669c"
+source = "git+https://github.com/arduano/midi-toolkit-rs?rev=cff22ac#cff22acf3a3113ac9f1f05b0fb8f9cd30f3f95ac"
 dependencies = [
  "convert_case",
  "num-traits",
@@ -3349,6 +3367,7 @@ dependencies = [
  "enum_dispatch",
  "gen-iter 0.3.0",
  "kdmapi",
+ "macro_pub",
  "midi-toolkit-rs",
  "miette",
  "palette",
@@ -3910,7 +3929,7 @@ checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 [[package]]
 name = "xsynth-core"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
+source = "git+https://github.com/arduano/xsynth.git?rev=4be1c7b#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
 dependencies = [
  "atomic_refcell",
  "biquad",
@@ -3929,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "xsynth-realtime"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
+source = "git+https://github.com/arduano/xsynth.git?rev=4be1c7b#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
 dependencies = [
  "atomic_refcell",
  "bytemuck",
@@ -3947,13 +3966,21 @@ dependencies = [
 [[package]]
 name = "xsynth-soundfonts"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
+source = "git+https://github.com/arduano/xsynth.git?rev=4be1c7b#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
 dependencies = [
+ "encoding_rs",
+ "encoding_rs_io",
  "lazy-regex",
  "regex-bnf",
  "simdeez 1.0.8 (git+https://github.com/arduano/simdeez.git?rev=86f8bf9)",
  "thiserror",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -797,7 +797,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys 0.4.0",
 ]
 
 [[package]]
@@ -809,6 +818,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -888,9 +908,10 @@ dependencies = [
 [[package]]
 name = "egui_file"
 version = "0.6.0"
-source = "git+https://github.com/Kaydax/egui_file.git#34008d89efc060ec096e5af3ceb2d3cf1b59bff1"
+source = "git+https://github.com/StratusFearMe21/egui_file.git#9ddcdcfe48bd593cb4ed5be85ac50d57432e49c9"
 dependencies = [
  "egui",
+ "fst",
 ]
 
 [[package]]
@@ -1173,6 +1194,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures-core"
@@ -3322,7 +3349,7 @@ dependencies = [
  "confy",
  "crossbeam-channel",
  "crossterm",
- "directories",
+ "dirs 5.0.0",
  "egui",
  "egui-winit",
  "egui_file",
@@ -3509,7 +3536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579cc485bd5ce5bfa0d738e4921dd0b956eca9800be1fd2e5257ebe95bc4617e"
 dependencies = [
  "core-foundation",
- "dirs",
+ "dirs 4.0.0",
  "jni 0.21.1",
  "log",
  "ndk-context",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,9 +888,9 @@ dependencies = [
 [[package]]
 name = "egui_file"
 version = "0.6.0"
-source = "git+https://github.com/Kaydax/egui_file.git#34008d89efc060ec096e5af3ceb2d3cf1b59bff1"
 dependencies = [
  "egui",
+ "fst",
 ]
 
 [[package]]
@@ -1173,6 +1173,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,9 +888,9 @@ dependencies = [
 [[package]]
 name = "egui_file"
 version = "0.6.0"
+source = "git+https://github.com/Kaydax/egui_file.git#34008d89efc060ec096e5af3ceb2d3cf1b59bff1"
 dependencies = [
  "egui",
- "fst",
 ]
 
 [[package]]
@@ -1173,12 +1173,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "fst"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,17 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -52,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5915f52fe2cf65e83924d037b6c5290b7cee097c6b5c8700746e6168a343fd6b"
 dependencies = [
  "alsa-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "nix 0.23.2",
 ]
@@ -65,6 +76,46 @@ checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -162,7 +213,7 @@ version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -196,6 +247,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
 
 [[package]]
 name = "block"
@@ -260,7 +317,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
- "clap",
+ "clap 3.2.23",
  "heck",
  "indexmap",
  "log",
@@ -321,12 +378,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
- "clap_lex",
+ "bitflags 1.3.2",
+ "clap_lex 0.2.4",
  "indexmap",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags 1.3.2",
+ "clap_lex 0.4.1",
+ "strsim",
 ]
 
 [[package]]
@@ -337,6 +416,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "clipboard-win"
@@ -364,7 +449,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
  "core-foundation",
@@ -380,7 +465,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-foundation",
  "core-graphics-types",
@@ -409,6 +494,21 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -451,7 +551,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types 0.3.2",
@@ -464,7 +564,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "foreign-types 0.3.2",
  "libc",
@@ -488,7 +588,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11894b20ebfe1ff903cbdc52259693389eea03b94918a2def2c30c3bf227ad88"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "coreaudio-sys",
 ]
 
@@ -607,6 +707,31 @@ dependencies = [
  "once_cell",
  "pkg-config",
  "servo-fontconfig",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
  "winapi",
 ]
 
@@ -739,7 +864,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65a5e883a316e53866977450eecfbcac9c48109c2ab3394af29feb83fcde4ea9"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "epaint",
  "nohash-hasher",
  "tracing",
@@ -763,7 +888,7 @@ dependencies = [
 [[package]]
 name = "egui_file"
 version = "0.6.0"
-source = "git+https://github.com/Kaydax/egui_file.git?rev=7ac26fb#7ac26fbfd4add5317dc8b9352a61eadde5cc5dbc"
+source = "git+https://github.com/Kaydax/egui_file.git#34008d89efc060ec096e5af3ceb2d3cf1b59bff1"
 dependencies = [
  "egui",
 ]
@@ -774,7 +899,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c16b9a2bcbfc85f5a4e1d91d1126958451c881c69efcc98e5d6b1b0e5fbb7419"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "bytemuck",
  "egui",
  "egui-winit",
@@ -806,6 +931,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,7 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de14b65fe5e423e0058f77a8beb2c863b056d0566d6c4ce0d097aa5814cb705a"
 dependencies = [
  "ab_glyph",
- "ahash",
+ "ahash 0.8.3",
  "atomic_refcell",
  "ecolor",
  "emath",
@@ -927,6 +1061,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fltk"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4670a59cce3acb71ee49bbda4d424e5856ddb496f35e29ffe3c9f387f9d2dd6c"
+dependencies = [
+ "bitflags 2.1.0",
+ "crossbeam-channel",
+ "fltk-sys",
+ "paste",
+ "ttf-parser",
+]
+
+[[package]]
+name = "fltk-sys"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2eb7a127947d0176a7bff2c7ea8d4db91cf674b38bbc6aae0b4e0e103c1f"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,7 +1158,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74eadec9d0a5c28c54bb9882e54787275152a4e36ce206b45d7451384e5bf5fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "freetype-sys",
  "libc",
 ]
@@ -1095,6 +1251,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "heck"
@@ -1195,6 +1354,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "kdmapi"
 version = "0.1.0"
-source = "git+https://github.com/arduano/kdmapi.git?rev=9329cfc#9329cfc57e808a5e05d537d1e4ae1bd219416292"
+source = "git+https://github.com/arduano/kdmapi.git#9329cfc57e808a5e05d537d1e4ae1bd219416292"
 dependencies = [
  "lazy_static",
  "libloading",
@@ -1420,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "midi-toolkit-rs"
 version = "0.1.0"
-source = "git+https://github.com/arduano/midi-toolkit-rs?rev=4482d61#4482d61eebe98442e3539ba0dc8bf39e0565669c"
+source = "git+https://github.com/arduano/midi-toolkit-rs#cff22acf3a3113ac9f1f05b0fb8f9cd30f3f95ac"
 dependencies = [
  "crossbeam-channel",
  "gen-iter 0.2.1",
@@ -1433,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "midi-toolkit-rs-derive"
 version = "0.1.0"
-source = "git+https://github.com/arduano/midi-toolkit-rs?rev=4482d61#4482d61eebe98442e3539ba0dc8bf39e0565669c"
+source = "git+https://github.com/arduano/midi-toolkit-rs#cff22acf3a3113ac9f1f05b0fb8f9cd30f3f95ac"
 dependencies = [
  "convert_case",
  "num-traits",
@@ -1441,6 +1618,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "miette"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abdc09c381c9336b9f2e9bd6067a9a5290d20e2d2e2296f275456121c33ae89"
+dependencies = [
+ "is-terminal",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap 0.15.2",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8842972f23939443013dfd3720f46772b743e86f1a81d120d4b6fb090f87de1c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -1495,7 +1702,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys 0.3.0",
  "num_enum",
@@ -1508,7 +1715,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys 0.4.1+23.1.7779620",
  "num_enum",
@@ -1575,7 +1782,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if",
  "libc",
@@ -1588,7 +1795,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -1601,7 +1808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -1778,6 +1985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "palette"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +2012,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "panicui"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ed19ff59fd7f9033ad171886c4a4a4b8030b438c975d673ddb88d9722e9c6a"
+dependencies = [
+ "fltk",
 ]
 
 [[package]]
@@ -1922,7 +2144,7 @@ version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2069,7 +2291,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2078,7 +2300,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2167,7 +2389,7 @@ version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2342,6 +2564,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,12 +2640,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "smithay-client-toolkit"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "calloop",
  "dlib",
  "lazy_static",
@@ -2497,6 +2755,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "supports-color"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4806e0b03b9906e76b018a5d821ebf198c8e9dc0829ed3328eeeb5094aed60"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
 name = "symphonia"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,7 +2850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b9567e2d8a5f866b2f94f5d366d811e0c6826babcff6d37de9e1a6690d38869"
 dependencies = [
  "arrayvec 0.7.2",
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
  "lazy_static",
  "log",
@@ -2670,6 +2956,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2864,6 +3171,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [
+ "hashbrown",
+ "regex",
+]
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +3188,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
@@ -2882,6 +3205,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vec_map"
@@ -2910,7 +3239,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f80b11c6c46ecb2c42155c8bcbc3ff04b783185181d4bbe19d9635a711ec747f"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "ash",
  "bytemuck",
  "core-graphics-types",
@@ -2938,7 +3267,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96bbe0784b21e32661fde8a883bb3f659a473693c9f23bab12c26d7884c15ed0"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "heck",
  "proc-macro2",
  "quote",
@@ -2953,7 +3282,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7d34bf37d622aa10d63a05396d91566d8298ca04ebc632f536946659a62f58"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "vulkano",
  "vulkano-win",
  "winit",
@@ -2988,9 +3317,11 @@ version = "0.1.0"
 dependencies = [
  "atomic_float",
  "bytemuck",
+ "clap 4.2.1",
  "colors-transform",
  "confy",
  "crossbeam-channel",
+ "crossterm",
  "directories",
  "egui",
  "egui-winit",
@@ -3000,12 +3331,15 @@ dependencies = [
  "gen-iter 0.3.0",
  "kdmapi",
  "midi-toolkit-rs",
+ "miette",
  "palette",
+ "panicui",
  "rand",
  "rayon",
  "rustc-hash",
  "serde",
  "serde_derive",
+ "thiserror",
  "toml 0.6.0",
  "vulkano",
  "vulkano-shaders",
@@ -3091,7 +3425,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "downcast-rs",
  "libc",
  "nix 0.24.3",
@@ -3130,7 +3464,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "wayland-client",
  "wayland-commons",
  "wayland-scanner",
@@ -3455,7 +3789,7 @@ version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb796d6fbd86b2fd896c9471e6f04d39d750076ebe5680a3958f00f5ab97657c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cocoa",
  "core-foundation",
  "core-graphics",
@@ -3557,7 +3891,7 @@ checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 [[package]]
 name = "xsynth-core"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
+source = "git+https://github.com/arduano/xsynth.git#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
 dependencies = [
  "atomic_refcell",
  "biquad",
@@ -3576,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "xsynth-realtime"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
+source = "git+https://github.com/arduano/xsynth.git#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
 dependencies = [
  "atomic_refcell",
  "bytemuck",
@@ -3594,8 +3928,10 @@ dependencies = [
 [[package]]
 name = "xsynth-soundfonts"
 version = "0.1.0"
-source = "git+https://github.com/arduano/xsynth.git?rev=87c24d1#87c24d1ccea2cb95a6b3ea71651d5e0ba0d8bb9d"
+source = "git+https://github.com/arduano/xsynth.git#4be1c7b342abb1c815f3224cfe99bd05a4e7043d"
 dependencies = [
+ "encoding_rs",
+ "encoding_rs_io",
  "lazy-regex",
  "regex-bnf",
  "simdeez 1.0.8 (git+https://github.com/arduano/simdeez.git?rev=86f8bf9)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ thiserror = "1.0.40"
 miette = { version = "5.7.0", features = ["fancy-no-backtrace"] }
 crossterm = "0.26.1"
 dirs = "5.0.0"
+macro_pub = "0.1.0"
 
 [profile.dev]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ colors-transform = "0.2.11"
 directories = "4.0.1"
 rustc-hash = "1.1.0"
 atomic_float = "0.1.0"
-# egui_file = { git = "https://github.com/Kaydax/egui_file.git" }
-egui_file = { path = "../egui_file" }
+egui_file = { git = "https://github.com/Kaydax/egui_file.git" }
 clap = "4.2.1"
 panicui = "0.1.0"
 thiserror = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,29 +11,29 @@ vulkano-shaders = "0.32.0"
 vulkano-win = "0.32.0"
 vulkano-util = "0.32.0"
 egui-winit = "0.20.1"
-bytemuck = "1.8.0"
+bytemuck = "1.13.1"
 vulkano = "0.32.3"
 kdmapi = { git = "https://github.com/arduano/kdmapi.git", rev = "9329cfc" }
 egui = "0.20.1"
-winit = "0.27.3"
-rayon = "1.5.3"
-midi-toolkit-rs = { git = "https://github.com/arduano/midi-toolkit-rs", rev = "4482d61" }
-xsynth-core = { git = "https://github.com/arduano/xsynth.git", rev = "87c24d1" }
-xsynth-realtime = { git = "https://github.com/arduano/xsynth.git", rev = "87c24d1" }
+winit = "0.27.5"
+rayon = "1.7.0"
+midi-toolkit-rs = { git = "https://github.com/arduano/midi-toolkit-rs", rev = "cff22ac" }
+xsynth-core = { git = "https://github.com/arduano/xsynth.git", rev = "4be1c7b" }
+xsynth-realtime = { git = "https://github.com/arduano/xsynth.git", rev = "4be1c7b" }
 gen-iter = "0.3.0"
-enum_dispatch = "0.3.8"
-palette = "0.6.0"
-crossbeam-channel = "0.5.5"
+enum_dispatch = "0.3.11"
+palette = "0.6.1"
+crossbeam-channel = "0.5.8"
 rand = "0.8.5"
 confy = "0.5.1"
-serde_derive = "1.0.145"
-serde = "1.0.145"
+serde_derive = "1.0.160"
+serde = "1.0.160"
 toml = "0.6.0"
 colors-transform = "0.2.11"
 rustc-hash = "1.1.0"
 atomic_float = "0.1.0"
 egui_file = { git = "https://github.com/StratusFearMe21/egui_file.git" }
-clap = "4.2.1"
+clap = "4.2.2"
 panicui = "0.1.0"
 thiserror = "1.0.40"
 miette = { version = "5.7.0", features = ["fancy-no-backtrace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ vulkano-util = "0.32.0"
 egui-winit = "0.20.1"
 bytemuck = "1.8.0"
 vulkano = "0.32.3"
-kdmapi = { git = "https://github.com/arduano/kdmapi.git" }
+kdmapi = { git = "https://github.com/arduano/kdmapi.git", rev = "9329cfc" }
 egui = "0.20.1"
 winit = "0.27.3"
 rayon = "1.5.3"
-midi-toolkit-rs = { git = "https://github.com/arduano/midi-toolkit-rs" }
-xsynth-core = { git = "https://github.com/arduano/xsynth.git" }
-xsynth-realtime = { git = "https://github.com/arduano/xsynth.git" }
+midi-toolkit-rs = { git = "https://github.com/arduano/midi-toolkit-rs", rev = "4482d61" }
+xsynth-core = { git = "https://github.com/arduano/xsynth.git", rev = "87c24d1" }
+xsynth-realtime = { git = "https://github.com/arduano/xsynth.git", rev = "87c24d1" }
 gen-iter = "0.3.0"
 enum_dispatch = "0.3.8"
 palette = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ colors-transform = "0.2.11"
 directories = "4.0.1"
 rustc-hash = "1.1.0"
 atomic_float = "0.1.0"
-egui_file = { git = "https://github.com/Kaydax/egui_file.git" }
+# egui_file = { git = "https://github.com/Kaydax/egui_file.git" }
+egui_file = { path = "../egui_file" }
 clap = "4.2.1"
 panicui = "0.1.0"
 thiserror = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ serde_derive = "1.0.145"
 serde = "1.0.145"
 toml = "0.6.0"
 colors-transform = "0.2.11"
-directories = "4.0.1"
 rustc-hash = "1.1.0"
 atomic_float = "0.1.0"
-egui_file = { git = "https://github.com/Kaydax/egui_file.git" }
+egui_file = { git = "https://github.com/StratusFearMe21/egui_file.git" }
 clap = "4.2.1"
 panicui = "0.1.0"
 thiserror = "1.0.40"
 miette = { version = "5.7.0", features = ["fancy-no-backtrace"] }
 crossterm = "0.26.1"
+dirs = "5.0.0"
 
 [profile.dev]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ vulkano-util = "0.32.0"
 egui-winit = "0.20.1"
 bytemuck = "1.8.0"
 vulkano = "0.32.3"
-kdmapi = { git = "https://github.com/arduano/kdmapi.git", rev = "9329cfc" }
+kdmapi = { git = "https://github.com/arduano/kdmapi.git" }
 egui = "0.20.1"
 winit = "0.27.3"
 rayon = "1.5.3"
-midi-toolkit-rs = { git = "https://github.com/arduano/midi-toolkit-rs", rev = "4482d61" }
-xsynth-core = { git = "https://github.com/arduano/xsynth.git", rev = "87c24d1" }
-xsynth-realtime = { git = "https://github.com/arduano/xsynth.git", rev = "87c24d1" }
+midi-toolkit-rs = { git = "https://github.com/arduano/midi-toolkit-rs" }
+xsynth-core = { git = "https://github.com/arduano/xsynth.git" }
+xsynth-realtime = { git = "https://github.com/arduano/xsynth.git" }
 gen-iter = "0.3.0"
 enum_dispatch = "0.3.8"
 palette = "0.6.0"
@@ -33,7 +33,12 @@ colors-transform = "0.2.11"
 directories = "4.0.1"
 rustc-hash = "1.1.0"
 atomic_float = "0.1.0"
-egui_file = { git = "https://github.com/Kaydax/egui_file.git", rev = "7ac26fb" }
+egui_file = { git = "https://github.com/Kaydax/egui_file.git" }
+clap = "4.2.1"
+panicui = "0.1.0"
+thiserror = "1.0.40"
+miette = { version = "5.7.0", features = ["fancy-no-backtrace"] }
+crossterm = "0.26.1"
 
 [profile.dev]
 opt-level = 2
@@ -41,4 +46,5 @@ opt-level = 2
 [profile.release]
 opt-level = 3
 codegen-units = 1
+panic = "abort"
 lto = true

--- a/src/audio_cli.rs
+++ b/src/audio_cli.rs
@@ -160,12 +160,12 @@ Q/Ctrl+c: Quit
                                     AudioPlayerType::XSynth {
                                         buffer: settings.synth.buffer_ms,
                                         ignore_range: settings.synth.vel_ignore.clone(),
-                                        options: convert_to_channel_init(&settings),
+                                        options: convert_to_channel_init(settings),
                                     },
                                 );
                                 synth.player.write().unwrap().set_soundfont(
                                     &settings.synth.sfz_path,
-                                    convert_to_sf_init(&settings),
+                                    convert_to_sf_init(settings),
                                 );
                                 synth.player.write().unwrap().set_layer_count(
                                     if settings.synth.limit_layers {

--- a/src/audio_cli.rs
+++ b/src/audio_cli.rs
@@ -1,0 +1,210 @@
+use std::io::{stdout, BufWriter, Write};
+use std::panic::PanicInfo;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::error::ErrorKind;
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::style::{self, Attribute};
+use crossterm::QueueableCommand;
+
+use crate::audio_playback::xsynth::{convert_to_channel_init, convert_to_sf_init};
+use crate::audio_playback::{AudioPlayerType, ManagedSynth};
+use crate::midi::MIDIFileBase;
+use crate::settings::{Synth, WasabiSettings};
+
+pub fn run_audio_cli(settings: &mut WasabiSettings) {
+    if settings.synth.sfz_path.is_empty() {
+        let err = clap::Error::raw(
+            ErrorKind::MissingRequiredArgument,
+            "The following was not provided through the config file, \
+            or the command line\n\t-s, --sfz-path <sfz-path>",
+        )
+        .with_cmd(&clap::Command::new("wasabi"));
+
+        err.exit();
+    }
+    let mut synth = ManagedSynth::new(settings);
+
+    let file: PathBuf = settings.load_midi_file.take().unwrap().into();
+    synth.load_midi(settings, file);
+
+    let mut stdout = BufWriter::new(stdout().lock());
+
+    stdout
+        .queue(style::SetAttribute(Attribute::Bold))
+        .unwrap()
+        .queue(style::SetAttribute(Attribute::Underlined))
+        .unwrap()
+        .write_all(b"\nKeyboard Controls:")
+        .unwrap();
+
+    stdout
+        .queue(style::ResetColor)
+        .unwrap()
+        .write_all(
+            br#"
+
+Space: Play/Pause
+Left Arrow: -10s
+Right Arrow: +10s
+Down Arrow: -60s
+Up Arrow: +60s
+R: Reload Synthesizer
+Q/Ctrl+c: Quit
+
+            "#,
+        )
+        .unwrap();
+
+    stdout.flush().unwrap();
+
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info: &PanicInfo| {
+        crossterm::terminal::disable_raw_mode().unwrap();
+        default_hook(info);
+    }));
+
+    crossterm::terminal::enable_raw_mode().unwrap();
+
+    loop {
+        if let Some(midi_file) = synth.midi_file.as_mut() {
+            let mut time = midi_file.timer().get_time().as_secs();
+            let length = midi_file.midi_length().unwrap() as u64;
+
+            if event::poll(Duration::from_secs(1)).unwrap() {
+                match event::read().unwrap() {
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Left,
+                        kind: KeyEventKind::Press,
+                        ..
+                    }) => {
+                        if midi_file.allows_seeking_backward() {
+                            if time > 10 {
+                                time -= 10;
+                            } else {
+                                time = 0;
+                            }
+                            midi_file.timer_mut().seek(Duration::from_secs(time));
+                        }
+                    }
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Down,
+                        kind: KeyEventKind::Press,
+                        ..
+                    }) => {
+                        if midi_file.allows_seeking_backward() {
+                            if time > 60 {
+                                time -= 60;
+                            } else {
+                                time = 0;
+                            }
+                            midi_file.timer_mut().seek(Duration::from_secs(time));
+                        }
+                    }
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Right,
+                        kind: KeyEventKind::Press,
+                        ..
+                    }) => {
+                        if (time + 10) < length {
+                            time += 10;
+                        } else {
+                            time = length;
+                        }
+                        midi_file.timer_mut().seek(Duration::from_secs(time));
+                    }
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Up,
+                        kind: KeyEventKind::Press,
+                        ..
+                    }) => {
+                        if (time + 60) < length {
+                            time += 60;
+                        } else {
+                            time = length;
+                        }
+                        midi_file.timer_mut().seek(Duration::from_secs(time));
+                    }
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Char(' '),
+                        kind: KeyEventKind::Press,
+                        ..
+                    }) => {
+                        midi_file.timer_mut().toggle_pause();
+                    }
+                    Event::Key(
+                        KeyEvent {
+                            code: KeyCode::Char('c'),
+                            kind: KeyEventKind::Press,
+                            modifiers: KeyModifiers::CONTROL,
+                            ..
+                        }
+                        | KeyEvent {
+                            code: KeyCode::Char('q'),
+                            kind: KeyEventKind::Press,
+                            ..
+                        },
+                    ) => {
+                        crossterm::terminal::disable_raw_mode().unwrap();
+                        return;
+                    }
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Char('r'),
+                        kind: KeyEventKind::Press,
+                        ..
+                    }) => {
+                        match settings.synth.synth {
+                            Synth::XSynth => {
+                                synth.player.write().unwrap().switch_player(
+                                    AudioPlayerType::XSynth {
+                                        buffer: settings.synth.buffer_ms,
+                                        ignore_range: settings.synth.vel_ignore.clone(),
+                                        options: convert_to_channel_init(&settings),
+                                    },
+                                );
+                                synth.player.write().unwrap().set_soundfont(
+                                    &settings.synth.sfz_path,
+                                    convert_to_sf_init(&settings),
+                                );
+                                synth.player.write().unwrap().set_layer_count(
+                                    if settings.synth.limit_layers {
+                                        Some(settings.synth.layer_count)
+                                    } else {
+                                        None
+                                    },
+                                );
+                            }
+                            Synth::Kdmapi => {
+                                synth
+                                    .player
+                                    .write()
+                                    .unwrap()
+                                    .switch_player(AudioPlayerType::Kdmapi);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            stdout
+                .queue(crossterm::terminal::Clear(
+                    crossterm::terminal::ClearType::CurrentLine,
+                ))
+                .unwrap()
+                .queue(crossterm::cursor::MoveToColumn(0))
+                .unwrap()
+                .write_fmt(format_args!(
+                    "[{:02}:{:02}/{:02}:{:02}]",
+                    time / 60,
+                    time % 60,
+                    length / 60,
+                    length % 60
+                ))
+                .unwrap();
+
+            stdout.flush().unwrap();
+        }
+    }
+}

--- a/src/audio_playback/xsynth.rs
+++ b/src/audio_playback/xsynth.rs
@@ -74,13 +74,13 @@ impl XSynthPlayer {
 
 pub fn convert_to_sf_init(settings: &WasabiSettings) -> SoundfontInitOptions {
     SoundfontInitOptions {
-        linear_release: settings.linear_envelope,
-        use_effects: settings.use_effects,
+        linear_release: settings.synth.linear_envelope,
+        use_effects: settings.synth.use_effects,
     }
 }
 
 pub fn convert_to_channel_init(settings: &WasabiSettings) -> ChannelInitOptions {
     ChannelInitOptions {
-        fade_out_killing: settings.fade_out_kill,
+        fade_out_killing: settings.synth.fade_out_kill,
     }
 }

--- a/src/gui/window/settings_window.rs
+++ b/src/gui/window/settings_window.rs
@@ -180,9 +180,6 @@ pub fn draw_settings(
             ui.separator();
             ui.vertical_centered(|ui| {
                 ui.label("Options marked with (*) will apply when a new MIDI is loaded.");
-                if ui.button("Save").clicked() {
-                    settings.save_to_file();
-                }
             });
         });
 }

--- a/src/gui/window/settings_window.rs
+++ b/src/gui/window/settings_window.rs
@@ -28,14 +28,6 @@ pub fn draw_settings(
         .show(ctx, |ui| {
             let col_width = 160.0;
 
-            // Big `Save Settings` button
-            if ui
-                .add_sized([450.0, 50.0], egui::Button::new("Save Settings"))
-                .clicked()
-            {
-                settings.save_to_file();
-            }
-
             // Synth settings section
             ui.heading("Synth");
             ui.separator();
@@ -180,6 +172,9 @@ pub fn draw_settings(
             ui.separator();
             ui.vertical_centered(|ui| {
                 ui.label("Options marked with (*) will apply when a new MIDI is loaded.");
+                if ui.button("Save").clicked() {
+                    settings.save_to_file();
+                }
             });
         });
 }

--- a/src/gui/window/settings_window.rs
+++ b/src/gui/window/settings_window.rs
@@ -8,7 +8,7 @@ use crate::{
         AudioPlayerType,
     },
     gui::window::GuiWasabiWindow,
-    settings::WasabiSettings,
+    settings::{MidiLoading, Synth, WasabiSettings},
     state::WasabiState,
 };
 
@@ -28,6 +28,14 @@ pub fn draw_settings(
         .show(ctx, |ui| {
             let col_width = 160.0;
 
+            // Big `Save Settings` button
+            if ui
+                .add_sized([450.0, 50.0], egui::Button::new("Save Settings"))
+                .clicked()
+            {
+                settings.save_to_file();
+            }
+
             // Synth settings section
             ui.heading("Synth");
             ui.separator();
@@ -38,39 +46,41 @@ pub fn draw_settings(
                 .min_col_width(col_width)
                 .show(ui, |ui| {
                     ui.label("Synth: ");
-                    let synth_prev = settings.synth;
+                    let synth_prev = settings.synth.synth;
                     let synth = ["XSynth", "KDMAPI"];
                     egui::ComboBox::from_id_source("synth_select").show_index(
                         ui,
-                        &mut settings.synth,
+                        unsafe {
+                            std::mem::transmute::<&mut Synth, &mut usize>(&mut settings.synth.synth)
+                        },
                         synth.len(),
                         |i| synth[i].to_owned(),
                     );
-                    if settings.synth != synth_prev {
-                        match settings.synth {
-                            1 => {
+                    if settings.synth.synth != synth_prev {
+                        match settings.synth.synth {
+                            Synth::Kdmapi => {
                                 win.synth
+                                    .player
                                     .write()
                                     .unwrap()
                                     .switch_player(AudioPlayerType::Kdmapi);
                             }
-                            _ => {
-                                win.synth
-                                    .write()
-                                    .unwrap()
-                                    .switch_player(AudioPlayerType::XSynth {
-                                        buffer: settings.buffer_ms,
-                                        ignore_range: settings.vel_ignore.clone(),
+                            Synth::XSynth => {
+                                win.synth.player.write().unwrap().switch_player(
+                                    AudioPlayerType::XSynth {
+                                        buffer: settings.synth.buffer_ms,
+                                        ignore_range: settings.synth.vel_ignore.clone(),
                                         options: convert_to_channel_init(settings),
-                                    });
-                                win.synth.write().unwrap().set_soundfont(
-                                    &settings.sfz_path,
+                                    },
+                                );
+                                win.synth.player.write().unwrap().set_soundfont(
+                                    &settings.synth.sfz_path,
                                     convert_to_sf_init(settings),
                                 );
-                                win.synth.write().unwrap().set_layer_count(
-                                    match settings.layer_count {
+                                win.synth.player.write().unwrap().set_layer_count(
+                                    match settings.synth.layer_count {
                                         0 => None,
-                                        _ => Some(settings.layer_count),
+                                        _ => Some(settings.synth.layer_count),
                                     },
                                 );
                             }
@@ -97,16 +107,19 @@ pub fn draw_settings(
                 .show(ui, |ui| {
                     ui.label("Note speed: ");
                     ui.spacing_mut().slider_width = 150.0;
-                    ui.add(egui::Slider::new(&mut settings.note_speed, 2.0..=0.001));
+                    ui.add(egui::Slider::new(
+                        &mut settings.midi.note_speed,
+                        2.0..=0.001,
+                    ));
                     ui.end_row();
 
                     ui.label("Random Track Colors*: ");
-                    ui.checkbox(&mut settings.random_colors, "");
+                    ui.checkbox(&mut settings.midi.random_colors, "");
                     ui.end_row();
 
                     ui.label("Keyboard Range: ");
-                    let mut firstkey = *settings.key_range.start();
-                    let mut lastkey = *settings.key_range.end();
+                    let mut firstkey = *settings.midi.key_range.start();
+                    let mut lastkey = *settings.midi.key_range.end();
                     ui.horizontal(|ui| {
                         ui.add(
                             egui::DragValue::new(&mut firstkey)
@@ -120,17 +133,21 @@ pub fn draw_settings(
                         );
                     });
                     ui.end_row();
-                    if firstkey != *settings.key_range.start()
-                        || lastkey != *settings.key_range.end()
+                    if firstkey != *settings.midi.key_range.start()
+                        || lastkey != *settings.midi.key_range.end()
                     {
-                        settings.key_range = firstkey..=lastkey;
+                        settings.midi.key_range = firstkey..=lastkey;
                     }
 
                     ui.label("MIDI Loading*: ");
                     let midi_loading = ["In RAM", "Live"];
                     egui::ComboBox::from_id_source("midiload_select").show_index(
                         ui,
-                        &mut settings.midi_loading,
+                        unsafe {
+                            std::mem::transmute::<&mut MidiLoading, &mut usize>(
+                                &mut settings.midi.midi_loading,
+                            )
+                        },
                         midi_loading.len(),
                         |i| midi_loading[i].to_owned(),
                     );
@@ -152,11 +169,11 @@ pub fn draw_settings(
                     ui.end_row();
 
                     ui.label("Background Color: ");
-                    ui.color_edit_button_srgba(&mut settings.bg_color);
+                    ui.color_edit_button_srgba(&mut settings.visual.bg_color);
                     ui.end_row();
 
                     ui.label("Bar Color: ");
-                    ui.color_edit_button_srgba(&mut settings.bar_color);
+                    ui.color_edit_button_srgba(&mut settings.visual.bar_color);
                     ui.end_row();
                 });
 

--- a/src/gui/window/settings_window.rs
+++ b/src/gui/window/settings_window.rs
@@ -12,12 +12,26 @@ use crate::{
     state::WasabiState,
 };
 
+include!("../../help/help_settings.rs");
+
+macro_rules! with_tooltip {
+    { $ui:expr;$short_help:expr,$long_help:expr,$shift:expr } => {{
+        let element = $ui;
+        if $shift {
+            element.on_hover_text_at_pointer(concat!($long_help, "\n\nHold H for more info"));
+        } else {
+            element.on_hover_text_at_pointer(concat!($short_help, "\n\nHold H for more info"));
+        }
+    }};
+}
+
 pub fn draw_settings(
     win: &mut GuiWasabiWindow,
     settings: &mut WasabiSettings,
     state: &mut WasabiState,
     ctx: &Context,
 ) {
+    let is_shift = ctx.input().key_down(egui::Key::H);
     egui::Window::new("Settings")
         .resizable(true)
         .collapsible(true)
@@ -40,14 +54,17 @@ pub fn draw_settings(
                     ui.label("Synth: ");
                     let synth_prev = settings.synth.synth;
                     let synth = ["XSynth", "KDMAPI"];
-                    egui::ComboBox::from_id_source("synth_select").show_index(
-                        ui,
-                        unsafe {
-                            std::mem::transmute::<&mut Synth, &mut usize>(&mut settings.synth.synth)
-                        },
-                        synth.len(),
-                        |i| synth[i].to_owned(),
-                    );
+                    with_tooltip! {
+                        egui::ComboBox::from_id_source("synth_select").show_index(
+                            ui,
+                            unsafe {
+                                std::mem::transmute::<&mut Synth, &mut usize>(&mut settings.synth.synth)
+                            },
+                            synth.len(),
+                            |i| synth[i].to_owned(),
+                        );
+                        synth_short_help!(), synth_long_help!(), is_shift
+                    }
                     if settings.synth.synth != synth_prev {
                         match settings.synth.synth {
                             Synth::Kdmapi => {
@@ -99,31 +116,40 @@ pub fn draw_settings(
                 .show(ui, |ui| {
                     ui.label("Note speed: ");
                     ui.spacing_mut().slider_width = 150.0;
-                    ui.add(egui::Slider::new(
-                        &mut settings.midi.note_speed,
-                        2.0..=0.001,
-                    ));
+                    with_tooltip! {
+                        ui.add(egui::Slider::new(
+                            &mut settings.midi.note_speed,
+                            2.0..=0.001,
+                        ));
+                        note_speed_short_help!(), note_speed_long_help!(), is_shift
+                    }
                     ui.end_row();
 
                     ui.label("Random Track Colors*: ");
-                    ui.checkbox(&mut settings.midi.random_colors, "");
+                    with_tooltip! {
+                        ui.checkbox(&mut settings.midi.random_colors, "");
+                        random_colors_short_help!(), random_colors_long_help!(), is_shift
+                    }
                     ui.end_row();
 
                     ui.label("Keyboard Range: ");
                     let mut firstkey = *settings.midi.key_range.start();
                     let mut lastkey = *settings.midi.key_range.end();
-                    ui.horizontal(|ui| {
-                        ui.add(
-                            egui::DragValue::new(&mut firstkey)
-                                .speed(1)
-                                .clamp_range(RangeInclusive::new(0, 253)),
-                        );
-                        ui.add(
-                            egui::DragValue::new(&mut lastkey)
-                                .speed(1)
-                                .clamp_range(RangeInclusive::new(firstkey + 1, 254)),
-                        );
-                    });
+                    with_tooltip! {
+                        ui.horizontal(|ui| {
+                            ui.add(
+                                egui::DragValue::new(&mut firstkey)
+                                    .speed(1)
+                                    .clamp_range(RangeInclusive::new(0, 253)),
+                            );
+                            ui.add(
+                                egui::DragValue::new(&mut lastkey)
+                                    .speed(1)
+                                    .clamp_range(RangeInclusive::new(firstkey + 1, 254)),
+                            );
+                        }).response;
+                        key_range_short_help!(), key_range_long_help!(), is_shift
+                    }
                     ui.end_row();
                     if firstkey != *settings.midi.key_range.start()
                         || lastkey != *settings.midi.key_range.end()
@@ -133,16 +159,19 @@ pub fn draw_settings(
 
                     ui.label("MIDI Loading*: ");
                     let midi_loading = ["In RAM", "Live"];
-                    egui::ComboBox::from_id_source("midiload_select").show_index(
-                        ui,
-                        unsafe {
-                            std::mem::transmute::<&mut MidiLoading, &mut usize>(
-                                &mut settings.midi.midi_loading,
-                            )
-                        },
-                        midi_loading.len(),
-                        |i| midi_loading[i].to_owned(),
-                    );
+                    with_tooltip! {
+                        egui::ComboBox::from_id_source("midiload_select").show_index(
+                            ui,
+                            unsafe {
+                                std::mem::transmute::<&mut MidiLoading, &mut usize>(
+                                    &mut settings.midi.midi_loading,
+                                )
+                            },
+                            midi_loading.len(),
+                            |i| midi_loading[i].to_owned(),
+                        );
+                        midi_loading_short_help!(), midi_loading_long_help!(), is_shift
+                    }
                 });
 
             // Visual settings section
@@ -161,11 +190,17 @@ pub fn draw_settings(
                     ui.end_row();
 
                     ui.label("Background Color: ");
-                    ui.color_edit_button_srgba(&mut settings.visual.bg_color);
+                    with_tooltip! {
+                        ui.color_edit_button_srgba(&mut settings.visual.bg_color);
+                        bg_color_short_help!(), bg_color_long_help!(), is_shift
+                    }
                     ui.end_row();
 
                     ui.label("Bar Color: ");
-                    ui.color_edit_button_srgba(&mut settings.visual.bar_color);
+                    with_tooltip! {
+                        ui.color_edit_button_srgba(&mut settings.visual.bar_color);
+                        bar_color_short_help!(), bar_color_long_help!(), is_shift
+                    }
                     ui.end_row();
                 });
 

--- a/src/gui/window/stats.rs
+++ b/src/gui/window/stats.rs
@@ -61,7 +61,7 @@ pub fn draw_stats(win: &mut GuiWasabiWindow, ctx: &Context, pos: Pos2, mut stats
 
             let mut load_type = -1; // 0=RAM, 1=Live
 
-            if let Some(midi_file) = win.midi_file.as_mut() {
+            if let Some(midi_file) = win.synth.midi_file.as_mut() {
                 stats.time_total = if let Some(length) = midi_file.midi_length() {
                     length
                 } else {

--- a/src/gui/window/top_panel.rs
+++ b/src/gui/window/top_panel.rs
@@ -25,11 +25,11 @@ pub fn draw_panel(
                     win.open_midi_dialog(state);
                 }
 
-                if let Some(midi_file) = win.midi_file.as_mut() {
+                if let Some(midi_file) = win.synth.midi_file.as_mut() {
                     if ui.button("Unload").clicked() {
                         midi_file.timer_mut().pause();
-                        win.synth.write().unwrap().reset();
-                        win.midi_file = None;
+                        win.synth.player.write().unwrap().reset();
+                        win.synth.midi_file = None;
                     }
                 }
 
@@ -45,12 +45,12 @@ pub fn draw_panel(
                 ui.add_space(10.0);
 
                 if ui.button("Play").clicked() {
-                    if let Some(midi_file) = win.midi_file.as_mut() {
+                    if let Some(midi_file) = win.synth.midi_file.as_mut() {
                         midi_file.timer_mut().play();
                     }
                 }
                 if ui.button("Pause").clicked() {
-                    if let Some(midi_file) = win.midi_file.as_mut() {
+                    if let Some(midi_file) = win.synth.midi_file.as_mut() {
                         midi_file.timer_mut().pause();
                     }
                 }
@@ -60,7 +60,8 @@ pub fn draw_panel(
                 ui.horizontal(|ui| {
                     ui.label("Note speed: ");
                     ui.add(
-                        egui::Slider::new(&mut settings.note_speed, 2.0..=0.001).show_value(false),
+                        egui::Slider::new(&mut settings.midi.note_speed, 2.0..=0.001)
+                            .show_value(false),
                     );
                 })
             });
@@ -68,7 +69,7 @@ pub fn draw_panel(
             ui.spacing_mut().slider_width = ctx.available_rect().width() - 20.0;
             let mut empty_slider =
                 || ui.add(egui::Slider::new(&mut 0.0, 0.0..=1.0).show_value(false));
-            if let Some(midi_file) = win.midi_file.as_mut() {
+            if let Some(midi_file) = win.synth.midi_file.as_mut() {
                 if let Some(length) = midi_file.midi_length() {
                     let mut time = midi_file.timer().get_time().as_secs_f64();
                     let time_prev = time;

--- a/src/help/help_cmdline.rs
+++ b/src/help/help_cmdline.rs
@@ -1,0 +1,123 @@
+macro_rules! help_mod {
+    { $($key:ident = $value:expr),+, }=> {
+        $(
+            macro_rules! $key {
+                () => {
+                    $value
+                };
+            }
+        )+
+    };
+}
+
+help_mod! {
+    synth_short_help = "The synthesizer to use",
+    synth_long_help =
+        "The synthesizer that is used to play the MIDI. \
+        This can either be XSynth (recommended) or KDMAPI. KDMAPI \
+        only works if you have OmniMidi installed, and are using Windows",
+
+    buffer_ms_short_help = "The size of the event buffer",
+    buffer_ms_long_help =
+        "The amount of time in milliseconds that events \
+        are held in the buffer before they are played. Making this \
+        option larger can help MIDI files play in real-time that wouldn't \
+        otherwise.",
+
+    sfz_path_short_help = "The path to an SFZ SoundFont",
+    sfz_path_long_help =
+        "The path to any SFZ soundfont. In audio only mode \
+    a soundfont must be passed either via the config file, or
+    this command line option. In the GUI you can set this under \
+        `Open Synth Settings > SFZ Path`",
+
+    layer_limit_short_help = "Disable the voice limiter",
+    layer_limit_long_help =
+        "Allow for the synth to create as many voices as \
+        needed to play the MIDI file faithfully",
+
+    layer_count_short_help = "The maximum amount of voices allowed",
+    layer_count_long_help =
+        "The maximum amount of voices allowed to play per key per channel",
+
+    vel_ignore_short_help = "The range of note velocities that the synth will discard",
+    vel_ignore_long_help =
+        "Two numbers, comma seperated, that represent a range of velocities \
+        that the synth will discard, making notes in the range inaudible.",
+
+    fade_out_kill_short_help = "Once a voice is killed, fade it out",
+    fade_out_kill_long_help =
+        "Once the synthesizer kills one of it's voices, it will fade it \
+        out as opposed to simply cutting it off",
+
+    linear_envelope_short_help = "??????????????",
+    linear_envelope_long_help =
+        "??????????",
+
+    no_effects_short_help = "Disable the synth's effects",
+    no_effects_long_help =
+        "Disable the effects that the synthesizer applies to the final audio \
+        render. These effects include a limiter to keep the audio from clipping, \
+        and a cutoff",
+
+    note_speed_short_help = "The speed that the notes travel on-screen",
+    note_speed_long_help =
+        "The speed at which the notes will move across the screen. This makes \
+        the notes physically longer, causing them to move faster on-screen",
+
+    random_colors_short_help = "Make each channel a random color",
+    random_colors_long_help =
+        "This causes each of the note channels to become a random color",
+
+    key_range_short_help = "The key range of the on-screen piano keyboard",
+    key_range_long_help =
+        "Two numbers, comma seperated, that describe the range \
+        of keys to be shown on the on-screen piano keyboard, the range must \
+        be less than 255 and more than 0",
+
+    midi_loading_short_help = "How the MIDI is loaded into `wasabi`",
+    midi_loading_long_help =
+        "The method in which the MIDI file is loaded into `wasabi`, the \
+        two possible options are `ram`, which loads the MIDI file entirely into \
+        RAM before beginning playback; and `live` which will read the MIDI file \
+        as it's being played back. The latter method is for using with systems \
+        with low memory",
+
+    audio_only_short_help = "Don't open a window, just play the MIDI",
+    audio_only_long_help =
+        "Only initialize the real time MIDI synthesizer, and don't open \
+        the `wasabi` window. This will cause a CLI to open which will allow you \
+        to control the playback of your MIDI file. You must pass a MIDI file to \
+        use this option, and you must have either set `sfz_path` in the config, or \
+        passed it via the command line argument",
+
+    bg_color_short_help = "The window background",
+    bg_color_long_help =
+        "A hex color string describing the background color of the window",
+
+    bar_color_short_help = "The color of the bar just above the piano",
+    bar_color_long_help =
+        "A hex color string describing the color of the bar just above \
+        the on-screen piano keyboard",
+
+    hide_top_panel_short_help = "Hide the top panel",
+    hide_top_panel_long_help =
+        "Hides the top panel from view when the app opens. It can be un-hidden \
+        with Ctrl+F",
+
+    hide_statistics_short_help = "Hide the statistics window",
+    hide_statistics_long_help =
+        "Hides the statistics window from view when the app opens. It can be \
+        un-hidden with Ctrl+G",
+
+    fullscreen_short_help = "Start `wasabi` in fullscreen",
+    fullscreen_long_help =
+        "Starts `wasabi` in fullscreen mode. `wasabi` will use \
+        borderless fullscreen mode on Linux systems running Wayland, \
+        and exclusive fullscreen mode for everyone else",
+
+    midi_file_short_help = "The MIDI file to immediately begin playing",
+    midi_file_long_help =
+        "This MIDI file is played immediately after the app's launch. \
+        This argument is required to use the `--audio-only` option",
+}

--- a/src/help/help_settings.rs
+++ b/src/help/help_settings.rs
@@ -34,7 +34,7 @@ help_mod! {
     midi_loading_short_help = "How the MIDI is loaded into `wasabi`",
     midi_loading_long_help =
         "The method in which the MIDI file is loaded into `wasabi`, the \
-        two possible options are `Into RAM`, which loads the MIDI file entirely into \
+        two possible options are `In RAM`, which loads the MIDI file entirely into \
         RAM before beginning playback; and `Live` which will read the MIDI file \
         as it's being played back. The latter method is for using with systems \
         with low memory",

--- a/src/help/help_settings.rs
+++ b/src/help/help_settings.rs
@@ -1,0 +1,49 @@
+macro_rules! help_mod {
+    { $($key:ident = $value:expr),+, }=> {
+        $(
+            macro_rules! $key {
+                () => {
+                    $value
+                };
+            }
+        )+
+    };
+}
+
+help_mod! {
+    synth_short_help = "The synthesizer to use",
+    synth_long_help =
+        "The synthesizer that is used to play the MIDI. \
+        This can either be XSynth (recommended) or KDMAPI. KDMAPI \
+        only works if you have OmniMidi installed, and are using Windows",
+
+    note_speed_short_help = "The speed that the notes travel on-screen",
+    note_speed_long_help =
+        "The speed at which the notes will move across the screen. This makes \
+        the notes physically longer, causing them to move faster on-screen",
+
+    random_colors_short_help = "Make each channel a random color",
+    random_colors_long_help =
+        "This causes each of the note channels to become a random color",
+
+    key_range_short_help = "The key range of the on-screen piano keyboard",
+    key_range_long_help =
+        "The range of keys to be shown on the on-screen piano keyboard, \
+        the range must be less than 255 and more than 0",
+
+    midi_loading_short_help = "How the MIDI is loaded into `wasabi`",
+    midi_loading_long_help =
+        "The method in which the MIDI file is loaded into `wasabi`, the \
+        two possible options are `Into RAM`, which loads the MIDI file entirely into \
+        RAM before beginning playback; and `Live` which will read the MIDI file \
+        as it's being played back. The latter method is for using with systems \
+        with low memory",
+
+    bg_color_short_help = "The window background",
+    bg_color_long_help =
+        "The background color of the window",
+
+    bar_color_short_help = "The color of the bar just above the piano",
+    bar_color_long_help =
+        "The color of the bar just above the on-screen piano keyboard",
+}

--- a/src/help/help_xsynth_settings.rs
+++ b/src/help/help_xsynth_settings.rs
@@ -1,0 +1,42 @@
+macro_rules! help_mod {
+    { $($key:ident = $value:expr),+, }=> {
+        $(
+            macro_rules! $key {
+                () => {
+                    $value
+                };
+            }
+        )+
+    };
+}
+
+help_mod! {
+    buffer_ms_short_help = "The size of the event buffer",
+    buffer_ms_long_help =
+        "The amount of time in milliseconds that events \
+        are held in the buffer before they are played. Making this \
+        option larger can help MIDI files play in real-time that wouldn't \
+        otherwise.",
+
+    sfz_path_short_help = "The path to an SFZ SoundFont",
+    sfz_path_long_help = "The path to an SFZ SoundFont",
+
+    layer_limit_short_help = "Enable the voice limiter",
+    layer_limit_long_help =
+        "Limit the number of voices that the synth can create to \
+        `Layer Count`",
+
+    layer_count_short_help = "The maximum amount of voices allowed",
+    layer_count_long_help =
+        "The maximum amount of voices allowed to play per key per channel",
+
+    linear_envelope_short_help = "??????????????",
+    linear_envelope_long_help =
+        "??????????",
+
+    use_effects_short_help = "Enable the synth's effects",
+    use_effects_long_help =
+        "Enable the effects that the synthesizer applies to the final audio \
+        render. These effects include a limiter to keep the audio from clipping, \
+        and a cutoff",
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -405,10 +405,11 @@ impl WasabiSettings {
                     .value_hint(ValueHint::FilePath),
             )
             .arg(
-                Arg::new("dont-limit-layers")
+                Arg::new("no-layer-limit")
+                    .short('L')
                     .help("??????????????")
                     .long_help("??????????")
-                    .long("dont-limit-layers")
+                    .long("no-layer-limit")
                     .action(ArgAction::SetFalse),
             )
             .arg(
@@ -445,7 +446,7 @@ impl WasabiSettings {
                 Arg::new("linear-envelope")
                     .help("??????????????")
                     .long_help("??????????")
-                    .short('L')
+                    .short('e')
                     .long("linear-envelope")
                     .action(ArgAction::SetTrue),
             )
@@ -523,6 +524,7 @@ impl WasabiSettings {
             )
             .arg(
                 Arg::new("bg-color")
+                    .short('c')
                     .help("The window background")
                     .long_help("A hex color string describing the background color of the window")
                     .long("bg-color")
@@ -530,6 +532,7 @@ impl WasabiSettings {
             )
             .arg(
                 Arg::new("bar-color")
+                    .short('C')
                     .help("The color of the bar just above the piano")
                     .long_help(
                         "A hex color string describing the color of the bar just above \
@@ -540,6 +543,7 @@ impl WasabiSettings {
             )
             .arg(
                 Arg::new("hide-top-pannel")
+                    .short('t')
                     .long_help(
                         "Hides the top panel from view when the app opens. It can be un-hidden \
                         with Ctrl+F",
@@ -550,6 +554,7 @@ impl WasabiSettings {
             )
             .arg(
                 Arg::new("hide-statistics")
+                    .short('T')
                     .help("Hide the statistics window")
                     .long_help(
                         "Hides the statistics window from view when the app opens. It can be \
@@ -613,7 +618,7 @@ impl WasabiSettings {
         set!(synth.synth, "synth");
         set!(synth.buffer_ms, "buffer-ms");
         set_owned!(synth.sfz_path, "sfz-path", String);
-        set_flag!(synth.limit_layers, "dont-limit-layers");
+        set_flag!(synth.limit_layers, "no-layer-limit");
         set!(synth.layer_count, "layer-count");
         set_owned!(synth.vel_ignore, "vel-ignore", RangeInclusive<u8>);
         set_flag!(synth.fade_out_kill, "fade-out-kill");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,5 @@
 use clap::{parser::ValueSource, value_parser, Arg, ArgAction, Command, ValueHint};
 use colors_transform::{Color, Rgb};
-use directories::BaseDirs;
 use egui::Color32;
 use miette::{Diagnostic, LabeledSpan, MietteHandlerOpts, NamedSource, ReportHandler};
 use serde_derive::{Deserialize, Serialize};
@@ -9,7 +8,7 @@ use std::{
     fs,
     io::Write,
     ops::{Range, RangeInclusive},
-    path::{Path, PathBuf},
+    path::Path,
     str::FromStr,
 };
 use xsynth_core::{channel::ChannelInitOptions, soundfont::SoundfontInitOptions};
@@ -644,8 +643,7 @@ impl WasabiSettings {
     }
 
     fn get_config_path() -> String {
-        if let Some(base_dirs) = BaseDirs::new() {
-            let mut path: PathBuf = base_dirs.config_dir().to_path_buf();
+        if let Some(mut path) = dirs::config_dir() {
             path.push("wasabi");
             path.push(CONFIG_PATH);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -332,6 +332,8 @@ impl<'a> Diagnostic for TomlError<'a> {
     }
 }
 
+include!("help/help_cmdline.rs");
+
 impl WasabiSettings {
     pub fn new_or_load() -> Result<Self, String> {
         let config_path = Self::get_config_path();
@@ -373,38 +375,24 @@ impl WasabiSettings {
             .about(env!("CARGO_PKG_DESCRIPTION"))
             .arg(
                 Arg::new("synth")
-                    .help("The synthesizer to use")
-                    .long_help(
-                        "The synthesizer that is used to play the MIDI. \
-                        This can either be XSynth (recommended) or KDMAPI. KDMAPI \
-                        only works if you have OmniMidi installed, and are using Windows",
-                    )
+                    .help(synth_short_help!())
+                    .long_help(synth_long_help!())
                     .short('S')
                     .long("synth")
                     .value_parser(Synth::from_str),
             )
             .arg(
                 Arg::new("buffer-ms")
-                    .help("The size of the event buffer")
-                    .long_help(
-                        "The amount of time in milliseconds that events \
-                        are held in the buffer before they are played. Making this \
-                        option larger can help MIDI files play in real-time that wouldn't \
-                        otherwise.",
-                    )
+                    .help(buffer_ms_short_help!())
+                    .long_help(buffer_ms_long_help!())
                     .short('b')
                     .long("buffer-ms")
                     .value_parser(f64_parser),
             )
             .arg(
                 Arg::new("sfz-path")
-                    .help("The path to an SFZ SoundFont")
-                    .long_help(
-                        "The path to any SFZ soundfont. In audio only mode \
-                        a soundfont must be passed either via the config file, or
-                        this command line option. In the GUI you can set this under \
-                        `Open Synth Settings > SFZ Path`",
-                    )
+                    .help(sfz_path_short_help!())
+                    .long_help(sfz_path_long_help!())
                     .short('s')
                     .long("sfz-path")
                     .value_hint(ValueHint::FilePath),
@@ -412,120 +400,88 @@ impl WasabiSettings {
             .arg(
                 Arg::new("no-layer-limit")
                     .short('L')
-                    .help("Disable the voice limiter")
-                    .long_help(
-                        "Allow for the synth to create as many voices as \
-                        needed to play the MIDI file faithfully",
-                    )
+                    .help(layer_limit_short_help!())
+                    .long_help(layer_limit_long_help!())
                     .long("no-layer-limit")
                     .conflicts_with("layer-count")
                     .action(ArgAction::SetFalse),
             )
             .arg(
                 Arg::new("layer-count")
-                    .help("The maximum amount of voice allowed")
-                    .long_help("The maximum amount of voices allowed to play per key per channel")
+                    .help(layer_count_short_help!())
+                    .long_help(layer_count_long_help!())
                     .short('l')
                     .long("layer-count")
                     .value_parser(value_parser!(usize)),
             )
             .arg(
                 Arg::new("vel-ignore")
-                    .help("The range of note velocities that the synth will discard")
-                    .long_help(
-                        "Two numbers, comma seperated, that represent a range of velocities \
-                        that the synth will discard, making notes in the range inaudible.",
-                    )
+                    .help(vel_ignore_short_help!())
+                    .long_help(vel_ignore_long_help!())
                     .short('v')
                     .long("vel-ignore")
                     .value_parser(range_parser),
             )
             .arg(
                 Arg::new("fade-out-kill")
-                    .help("Once a voice is killed, fade it out")
-                    .long_help(
-                        "Once the synthesizer kills one of it's voices, it will fade it \
-                        out as opposed to simply cutting it off",
-                    )
+                    .help(fade_out_kill_short_help!())
+                    .long_help(fade_out_kill_long_help!())
                     .short('F')
                     .long("fade-out-kill")
                     .action(ArgAction::SetTrue),
             )
             .arg(
                 Arg::new("linear-envelope")
-                    .help("??????????????")
-                    .long_help("??????????")
+                    .help(linear_envelope_short_help!())
+                    .long_help(linear_envelope_long_help!())
                     .short('e')
                     .long("linear-envelope")
                     .action(ArgAction::SetTrue),
             )
             .arg(
                 Arg::new("no-effects")
-                    .help("Disable the synth's effects")
-                    .long_help(
-                        "Disable the effects that the synthesizer applies to the final audio \
-                        render. These effects include a limiter to keep the audio from clipping, \
-                        and a cutoff",
-                    )
+                    .help(no_effects_short_help!())
+                    .long_help(no_effects_long_help!())
                     .short('N')
                     .long("no-effects")
                     .action(ArgAction::SetFalse),
             )
             .arg(
                 Arg::new("note-speed")
-                    .help("The speed that the notes travel on-screen")
-                    .long_help(
-                        "The speed at which the notes will move across the screen. This makes \
-                        the notes physically longer, causing them to move faster on-screen",
-                    )
+                    .help(note_speed_short_help!())
+                    .long_help(note_speed_long_help!())
                     .short('n')
                     .long("note-speed")
                     .value_parser(note_speed),
             )
             .arg(
                 Arg::new("random-colors")
-                    .help("Make each channel a random color")
-                    .long_help("This causes each of the note channels to become a random color")
+                    .help(random_colors_short_help!())
+                    .long_help(random_colors_long_help!())
                     .short('r')
                     .long("random-colors")
                     .action(ArgAction::SetTrue),
             )
             .arg(
                 Arg::new("key-range")
-                    .help("The key range of the on-screen piano keyboard")
-                    .long_help(
-                        "Two numbers, comma seperated, that describe the range \
-                        of keys to be shown on the on-screen piano keyboard, the range must \
-                        be less than 255 and more than 0",
-                    )
+                    .help(key_range_short_help!())
+                    .long_help(key_range_long_help!())
                     .short('k')
                     .long("key-range")
                     .value_parser(range_parser),
             )
             .arg(
                 Arg::new("midi-loading")
-                    .help("How the MIDI is loaded into `wasabi`")
-                    .long_help(
-                        "The method in which the MIDI file is loaded into `wasabi`, the \
-                        two possible options are `ram`, which loads the MIDI file entirely into \
-                        RAM before beginning playback; and `live` which will read the MIDI file \
-                        as it's being played back. The latter method is for using with systems \
-                        with low memory",
-                    )
+                    .help(midi_loading_short_help!())
+                    .long_help(midi_loading_long_help!())
                     .short('m')
                     .long("midi-loading")
                     .value_parser(MidiLoading::from_str),
             )
             .arg(
                 Arg::new("audio-only")
-                    .help("Don't open a window, just play the MIDI")
-                    .long_help(
-                        "Only initialize the real time MIDI synthesizer, and don't open \
-                        the `wasabi` window. This will cause a CLI to open which will allow you \
-                        to control the playback of your MIDI file. You must pass a MIDI file to \
-                        use this option, and you must have either set `sfz_path` in the config, or \
-                        passed it via the command line argument",
-                    )
+                    .help(audio_only_short_help!())
+                    .long_help(audio_only_long_help!())
                     .short('a')
                     .long("audio-only")
                     .requires("midi-file")
@@ -533,65 +489,49 @@ impl WasabiSettings {
             )
             .arg(
                 Arg::new("bg-color")
+                    .help(bg_color_short_help!())
+                    .long_help(bg_color_long_help!())
                     .short('c')
-                    .help("The window background")
-                    .long_help("A hex color string describing the background color of the window")
                     .long("bg-color")
                     .value_parser(color_parser),
             )
             .arg(
                 Arg::new("bar-color")
+                    .help(bar_color_short_help!())
+                    .long_help(bar_color_long_help!())
                     .short('C')
-                    .help("The color of the bar just above the piano")
-                    .long_help(
-                        "A hex color string describing the color of the bar just above \
-                         the on-screen piano keyboard",
-                    )
                     .long("bar-color")
                     .value_parser(color_parser),
             )
             .arg(
                 Arg::new("hide-top-pannel")
+                    .help(hide_top_panel_short_help!())
+                    .long_help(hide_top_panel_long_help!())
                     .short('t')
-                    .long_help(
-                        "Hides the top panel from view when the app opens. It can be un-hidden \
-                        with Ctrl+F",
-                    )
-                    .help("Hide the top panel")
                     .long("hide-top-pannel")
                     .action(ArgAction::SetFalse),
             )
             .arg(
                 Arg::new("hide-statistics")
+                    .help(hide_statistics_short_help!())
+                    .long_help(hide_statistics_long_help!())
                     .short('T')
-                    .help("Hide the statistics window")
-                    .long_help(
-                        "Hides the statistics window from view when the app opens. It can be \
-                        un-hidden with Ctrl+G",
-                    )
                     .long("hide-statistics")
                     .action(ArgAction::SetFalse),
             )
             .arg(
                 Arg::new("fullscreen")
-                    .help("Start `wasabi` in fullscreen")
-                    .long_help(
-                        "Starts `wasabi` in fullscreen mode. `wasabi` will use \
-                        borderless fullscreen mode on Linux systems running Wayland, \
-                        and exclusive fullscreen mode for everyone else",
-                    )
+                    .help(fullscreen_short_help!())
+                    .long_help(fullscreen_long_help!())
                     .short('f')
                     .long("fullscreen")
                     .action(ArgAction::SetTrue),
             )
             .arg(
                 Arg::new("midi-file")
-                    .value_hint(ValueHint::FilePath)
-                    .help("The MIDI file to immediately begin playing")
-                    .long_help(
-                        "This MIDI file is played immediately after the app's launch. \
-                        This argument is required to use the `--audio-only` option",
-                    ),
+                    .help(midi_file_short_help!())
+                    .long_help(midi_file_long_help!())
+                    .value_hint(ValueHint::FilePath),
             )
             .get_matches();
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,160 +1,364 @@
+use clap::{parser::ValueSource, value_parser, Arg, ArgAction, Command, ValueHint};
 use colors_transform::{Color, Rgb};
 use directories::BaseDirs;
 use egui::Color32;
+use miette::{Diagnostic, LabeledSpan, MietteHandlerOpts, NamedSource, ReportHandler};
 use serde_derive::{Deserialize, Serialize};
 use std::{
+    fmt::Debug,
     fs,
     io::Write,
-    ops::RangeInclusive,
+    ops::{Range, RangeInclusive},
     path::{Path, PathBuf},
+    str::FromStr,
 };
 use xsynth_core::{channel::ChannelInitOptions, soundfont::SoundfontInitOptions};
 use xsynth_realtime::config::XSynthRealtimeConfig;
 
-#[derive(Deserialize, Serialize)]
-struct WasabiConfigFile {
-    note_speed: f64,
-    bg_color: String,
-    bar_color: String,
-    random_colors: bool,
-    sfz_path: String,
-    first_key: u8,
-    last_key: u8,
-    midi_loading: usize,
-    buffer_ms: f64,
-    limit_layers: bool,
-    layer_count: usize,
-    fade_out_kill: bool,
-    linear_envelope: bool,
-    use_effects: bool,
-    vel_ignore_lo: u8,
-    vel_ignore_hi: u8,
-    synth: usize,
+#[inline(always)]
+fn f64_parser(s: &str) -> Result<f64, String> {
+    s.parse().map_err(|e| format!("{}", e))
 }
 
-pub struct WasabiSettings {
-    pub note_speed: f64,
+#[inline(always)]
+fn note_speed(s: &str) -> Result<f64, String> {
+    let num: f64 = f64_parser(s)?;
+    if (0.0001..=2.0).contains(&num) {
+        Ok(2.0001 - num)
+    } else {
+        Err(String::from("Number must be between >0 and 2.0"))
+    }
+}
+
+#[inline(always)]
+fn color_parser(s: &str) -> Result<Color32, String> {
+    let rgb = Rgb::from_hex_str(s).map_err(|e| e.message)?;
+    Ok(Color32::from_rgb(
+        rgb.get_red() as u8,
+        rgb.get_green() as u8,
+        rgb.get_blue() as u8,
+    ))
+}
+
+#[inline(always)]
+fn range_parser(s: &str) -> Result<RangeInclusive<u8>, String> {
+    let range = s
+        .split_once(",")
+        .ok_or_else(|| String::from("This argument requires 2 numbers, comma seperated"))?;
+
+    Ok(range.0.parse().map_err(|e| format!("{}", e))?
+        ..=range.1.parse().map_err(|e| format!("{}", e))?)
+}
+
+mod color32_serde {
+    use colors_transform::Rgb;
+    use egui::Color32;
+    use serde::{de::Visitor, Deserializer, Serializer};
+
+    use super::color_parser;
+
+    pub fn serialize<S>(color: &Color32, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex_color =
+            Rgb::from(color.r() as f32, color.g() as f32, color.b() as f32).to_css_hex_string();
+
+        ser.serialize_str(&hex_color)
+    }
+
+    pub struct ColorVisitor;
+
+    impl<'de> Visitor<'de> for ColorVisitor {
+        type Value = Color32;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("A color encoded as a hex string")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            color_parser(v)
+                .map_err(|e| E::invalid_value(serde::de::Unexpected::Str(v), &e.as_str()))
+        }
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<Color32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        de.deserialize_str(ColorVisitor)
+    }
+}
+
+mod range_serde {
+    use std::ops::RangeInclusive;
+
+    use serde::{
+        de::{self, Visitor},
+        ser::SerializeStruct,
+        Deserializer, Serializer,
+    };
+
+    use serde_derive::Deserialize;
+
+    pub fn serialize<S>(range: &RangeInclusive<u8>, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut ser_struct = ser.serialize_struct("range", 2)?;
+        ser_struct.serialize_field("hi", range.start())?;
+        ser_struct.serialize_field("lo", range.end())?;
+        ser_struct.end()
+    }
+
+    #[derive(Deserialize)]
+    #[serde(field_identifier, rename_all = "lowercase")]
+    enum Field {
+        Hi,
+        Lo,
+    }
+
+    pub struct RangeVisitor;
+
+    impl<'de> Visitor<'de> for RangeVisitor {
+        type Value = RangeInclusive<u8>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("A color encoded as a hex string")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut hi = None;
+            let mut lo = None;
+            while let Some(key) = map.next_key::<Field>()? {
+                match key {
+                    Field::Hi => {
+                        if hi.is_some() {
+                            return Err(de::Error::duplicate_field("hi"));
+                        }
+                        hi = Some(map.next_value::<u8>()?);
+                    }
+                    Field::Lo => {
+                        if lo.is_some() {
+                            return Err(de::Error::duplicate_field("lo"));
+                        }
+                        lo = Some(map.next_value::<u8>()?);
+                    }
+                }
+            }
+
+            let hi = hi.ok_or_else(|| de::Error::missing_field("hi"))?;
+            let lo = lo.ok_or_else(|| de::Error::missing_field("lo"))?;
+
+            Ok(hi..=lo)
+        }
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<RangeInclusive<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        de.deserialize_struct("range", &["hi", "lo"], RangeVisitor)
+    }
+}
+
+#[repr(usize)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum MidiLoading {
+    Ram = 0,
+    Live = 1,
+}
+
+impl FromStr for MidiLoading {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ram" | "RAM" | "Ram" => Ok(MidiLoading::Ram),
+            "live" | "Live" => Ok(MidiLoading::Live),
+            s => Err(format!(
+                "{} was not expected. Expected one of `ram`, or `live`",
+                s
+            )),
+        }
+    }
+}
+
+#[repr(usize)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Synth {
+    XSynth = 0,
+    Kdmapi = 1,
+}
+
+impl FromStr for Synth {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "xsynth" | "XSynth" => Ok(Synth::XSynth),
+            "kdmapi" | "KDMPAI" => Ok(Synth::Kdmapi),
+            s => Err(format!(
+                "{} was not expected. Expected one of `xsynth`, or `kdmapi`",
+                s
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VisualSettings {
+    pub audio_only: bool,
+    #[serde(with = "color32_serde")]
     pub bg_color: Color32,
+    #[serde(with = "color32_serde")]
     pub bar_color: Color32,
+    pub show_top_pannel: bool,
+    pub show_statistics: bool,
+    pub fullscreen: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MidiSettings {
+    pub note_speed: f64,
     pub random_colors: bool,
-    pub sfz_path: String,
+    #[serde(with = "range_serde")]
     pub key_range: RangeInclusive<u8>,
-    pub midi_loading: usize,
+    pub midi_loading: MidiLoading,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SynthSettings {
+    pub synth: Synth,
     pub buffer_ms: f64,
+    pub sfz_path: String,
     pub limit_layers: bool,
     pub layer_count: usize,
+    #[serde(with = "range_serde")]
+    pub vel_ignore: RangeInclusive<u8>,
     pub fade_out_kill: bool,
     pub linear_envelope: bool,
     pub use_effects: bool,
-    pub vel_ignore: RangeInclusive<u8>,
-    pub synth: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WasabiSettings {
+    pub synth: SynthSettings,
+    pub midi: MidiSettings,
+    pub visual: VisualSettings,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_midi_file: Option<String>,
 }
 
 impl Default for WasabiSettings {
     fn default() -> Self {
         WasabiSettings {
-            note_speed: 0.25,
-            bg_color: Color32::from_rgb(30, 30, 30),
-            bar_color: Color32::from_rgb(145, 0, 0),
-            random_colors: false,
-            sfz_path: "".to_string(),
-            key_range: 0..=127,
-            midi_loading: 0,
-            buffer_ms: XSynthRealtimeConfig::default().render_window_ms,
-            limit_layers: true,
-            layer_count: 4,
-            fade_out_kill: ChannelInitOptions::default().fade_out_killing,
-            linear_envelope: SoundfontInitOptions::default().linear_release,
-            use_effects: SoundfontInitOptions::default().use_effects,
-            vel_ignore: 0..=0,
-            synth: 0,
+            synth: SynthSettings {
+                synth: Synth::XSynth,
+                buffer_ms: XSynthRealtimeConfig::default().render_window_ms,
+                sfz_path: String::new(),
+                limit_layers: true,
+                layer_count: 4,
+                vel_ignore: 0..=0,
+                fade_out_kill: ChannelInitOptions::default().fade_out_killing,
+                linear_envelope: SoundfontInitOptions::default().linear_release,
+                use_effects: SoundfontInitOptions::default().use_effects,
+            },
+            midi: MidiSettings {
+                note_speed: 0.25,
+                random_colors: false,
+                key_range: 0..=127,
+                midi_loading: MidiLoading::Ram,
+            },
+            visual: VisualSettings {
+                audio_only: false,
+                bg_color: Color32::from_rgb(30, 30, 30),
+                bar_color: Color32::from_rgb(145, 0, 0),
+                show_top_pannel: true,
+                show_statistics: true,
+                fullscreen: false,
+            },
+            load_midi_file: None,
         }
     }
 }
 
-static CONFIG_PATH: &str = "wasabi_config.toml";
+static CONFIG_PATH: &str = "wasabi-config.toml";
+
+#[derive(thiserror::Error)]
+#[error("There was an error parsing the config file")]
+struct TomlError<'a> {
+    message: &'a str,
+    src: NamedSource,
+    err_span: Option<Range<usize>>,
+}
+
+impl<'a> Debug for TomlError<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        MietteHandlerOpts::new()
+            .terminal_links(false)
+            .color(false)
+            .tab_width(4)
+            .build()
+            .debug(self, f)
+    }
+}
+
+impl<'a> Diagnostic for TomlError<'a> {
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.src)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        Some(Box::new(
+            [if let Some(ref err_span) = self.err_span {
+                LabeledSpan::new(
+                    Some(self.message.to_string()),
+                    err_span.start,
+                    err_span.len(),
+                )
+            } else {
+                LabeledSpan::new(Some(self.message.to_string()), 0, 1)
+            }]
+            .into_iter(),
+        ))
+    }
+}
 
 impl WasabiSettings {
-    pub fn new_or_load() -> Self {
+    pub fn new_or_load() -> Result<Self, String> {
         let config_path = Self::get_config_path();
-        if !Path::new(&config_path).exists() {
+        let mut config = if !Path::new(&config_path).exists() {
             Self::load_and_save_defaults()
         } else {
-            match fs::read_to_string(&config_path) {
-                Ok(content) => match toml::from_str::<WasabiConfigFile>(&content) {
-                    Ok(cfg) => {
-                        if let (Ok(bg), Ok(bar)) = (
-                            Rgb::from_hex_str(&cfg.bg_color),
-                            Rgb::from_hex_str(&cfg.bar_color),
-                        ) {
-                            Self {
-                                note_speed: cfg.note_speed,
-                                bg_color: Color32::from_rgb(
-                                    bg.get_red() as u8,
-                                    bg.get_green() as u8,
-                                    bg.get_blue() as u8,
-                                ),
-                                bar_color: Color32::from_rgb(
-                                    bar.get_red() as u8,
-                                    bar.get_green() as u8,
-                                    bar.get_blue() as u8,
-                                ),
-                                random_colors: cfg.random_colors,
-                                sfz_path: cfg.sfz_path,
-                                key_range: cfg.first_key..=cfg.last_key,
-                                midi_loading: cfg.midi_loading,
-                                buffer_ms: cfg.buffer_ms,
-                                limit_layers: cfg.limit_layers,
-                                layer_count: cfg.layer_count,
-                                fade_out_kill: cfg.fade_out_kill,
-                                linear_envelope: cfg.linear_envelope,
-                                use_effects: cfg.use_effects,
-                                vel_ignore: cfg.vel_ignore_lo..=cfg.vel_ignore_hi,
-                                synth: cfg.synth,
-                            }
-                        } else {
-                            Self::load_and_save_defaults()
-                        }
+            let config = fs::read_to_string(&config_path).unwrap();
+            toml::from_str(&config).map_err(|e| {
+                format!(
+                    "{:?}",
+                    TomlError {
+                        message: e.message(),
+                        src: NamedSource::new(config_path, config),
+                        err_span: e.span(),
                     }
-                    Err(..) => Self::load_and_save_defaults(),
-                },
-                Err(..) => Self::load_and_save_defaults(),
-            }
-        }
+                )
+            })?
+        };
+
+        config.augment_from_args();
+        Ok(config)
     }
 
     pub fn save_to_file(&self) {
         let config_path = Self::get_config_path();
-        let cfg = WasabiConfigFile {
-            note_speed: self.note_speed,
-            bg_color: Rgb::from(
-                self.bg_color.r() as f32,
-                self.bg_color.g() as f32,
-                self.bg_color.b() as f32,
-            )
-            .to_css_hex_string(),
-            bar_color: Rgb::from(
-                self.bar_color.r() as f32,
-                self.bar_color.g() as f32,
-                self.bar_color.b() as f32,
-            )
-            .to_css_hex_string(),
-            random_colors: self.random_colors,
-            sfz_path: self.sfz_path.clone(),
-            first_key: *self.key_range.start(),
-            last_key: *self.key_range.end(),
-            midi_loading: self.midi_loading,
-            buffer_ms: self.buffer_ms,
-            limit_layers: self.limit_layers,
-            layer_count: self.layer_count,
-            fade_out_kill: self.fade_out_kill,
-            linear_envelope: self.linear_envelope,
-            use_effects: self.use_effects,
-            vel_ignore_lo: *self.vel_ignore.start(),
-            vel_ignore_hi: *self.vel_ignore.end(),
-            synth: self.synth,
-        };
-        let toml: String = toml::to_string(&cfg).unwrap();
+        let toml: String = toml::to_string(&self).unwrap();
         if Path::new(&config_path).exists() {
             fs::remove_file(&config_path).expect("Error deleting old config");
         }
@@ -163,34 +367,299 @@ impl WasabiSettings {
             .expect("Error creating config");
     }
 
-    fn load_and_save_defaults() -> Self {
-        match fs::remove_file(CONFIG_PATH) {
-            Ok(..) => {
-                let cfg = Self::default();
-                Self::save_to_file(&cfg);
-                cfg
-            }
-            Err(..) => Self::default(),
+    fn augment_from_args(&mut self) {
+        let matches = Command::new("wasabi")
+            .version(env!("CARGO_PKG_VERSION"))
+            .author(env!("CARGO_PKG_AUTHORS"))
+            .about(env!("CARGO_PKG_DESCRIPTION"))
+            .arg(
+                Arg::new("synth")
+                    .help("The synthesizer to use")
+                    .long_help(
+                        "The synthesizer that is used to play the MIDI. \
+                        This can either be XSynth (recommended) or KDMAPI. KDMAPI \
+                        only works if you have OmniMidi installed, and are using Windows",
+                    )
+                    .short('S')
+                    .long("synth")
+                    .value_parser(Synth::from_str),
+            )
+            .arg(
+                Arg::new("buffer-ms")
+                    .help("??????????????")
+                    .long_help("??????????")
+                    .short('b')
+                    .long("buffer-ms")
+                    .value_parser(f64_parser),
+            )
+            .arg(
+                Arg::new("sfz-path")
+                    .help("The path to an SFZ SoundFont")
+                    .long_help(
+                        "The path to any SFZ soundfont. In audio only mode \
+                        a soundfont must be passed either via the config file, or
+                        this command line option. In the GUI you can set this under \
+                        `Open Synth Settings > SFZ Path`",
+                    )
+                    .short('s')
+                    .long("sfz-path")
+                    .value_hint(ValueHint::FilePath),
+            )
+            .arg(
+                Arg::new("dont-limit-layers")
+                    .help("??????????????")
+                    .long_help("??????????")
+                    .long("dont-limit-layers")
+                    .action(ArgAction::SetFalse),
+            )
+            .arg(
+                Arg::new("layer-count")
+                    .help("??????????????")
+                    .long_help("??????????")
+                    .short('l')
+                    .long("layer-count")
+                    .value_parser(value_parser!(usize)),
+            )
+            .arg(
+                Arg::new("vel-ignore")
+                    .help("The range of note velocities that the synth will discard")
+                    .long_help(
+                        "Two numbers, comma seperated, that represent a range of velocities \
+                        that the synth will discard, making notes in the range inaudible.",
+                    )
+                    .short('v')
+                    .long("vel-ignore")
+                    .value_parser(range_parser),
+            )
+            .arg(
+                Arg::new("fade-out-kill")
+                    .help("Once a voice is killed, fade it out")
+                    .long_help(
+                        "Once the synthesizer kills one of it's voices, it will fade it \
+                        out as opposed to simply cutting it off",
+                    )
+                    .short('F')
+                    .long("fade-out-kill")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("linear-envelope")
+                    .help("??????????????")
+                    .long_help("??????????")
+                    .short('L')
+                    .long("linear-envelope")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("no-effects")
+                    .help("Disable the synth's effects")
+                    .long_help(
+                        "Disable the effects that the synthesizer applies to the final audio \
+                        render. These effects include a limiter to keep the audio from clipping, \
+                        and a cutoff",
+                    )
+                    .short('N')
+                    .long("no-effects")
+                    .action(ArgAction::SetFalse),
+            )
+            .arg(
+                Arg::new("note-speed")
+                    .help("The speed that the notes travel on-screen")
+                    .long_help(
+                        "The speed at which the notes will move across the screen. This makes \
+                        the notes physically longer, causing them to move faster on-screen",
+                    )
+                    .short('n')
+                    .long("note-speed")
+                    .value_parser(note_speed),
+            )
+            .arg(
+                Arg::new("random-colors")
+                    .help("Make each channel a random color")
+                    .long_help("This causes each of the note channels to become a random color")
+                    .short('r')
+                    .long("random-colors")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("key-range")
+                    .help("The key range of the on-screen piano keyboard")
+                    .long_help(
+                        "Two numbers, comma seperated, that describe the range \
+                        of keys to be shown on the on-screen piano keyboard, the range must \
+                        be less than 255 and more than 0",
+                    )
+                    .short('k')
+                    .long("key-range")
+                    .value_parser(range_parser),
+            )
+            .arg(
+                Arg::new("midi-loading")
+                    .help("How the MIDI is loaded into `wasabi`")
+                    .long_help(
+                        "The method in which the MIDI file is loaded into `wasabi`, the \
+                        two possible options are `ram`, which loads the MIDI file entirely into \
+                        RAM before beginning playback; and `live` which will read the MIDI file \
+                        as it's being played back. The latter method is for using with systems \
+                        with low memory",
+                    )
+                    .short('m')
+                    .long("midi-loading")
+                    .value_parser(MidiLoading::from_str),
+            )
+            .arg(
+                Arg::new("audio-only")
+                    .help("Don't open a window, just play the MIDI")
+                    .long_help(
+                        "Only initialize the real time MIDI synthesizer, and don't open \
+                        the `wasabi` window. This will cause a CLI to open which will allow you \
+                        to control the playback of your MIDI file. You must pass a MIDI file to \
+                        use this option, and you must have either set `sfz_path` in the config, or \
+                        passed it via the command line argument",
+                    )
+                    .short('a')
+                    .long("audio-only")
+                    .requires("midi-file")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("bg-color")
+                    .help("The window background")
+                    .long_help("A hex color string describing the background color of the window")
+                    .long("bg-color")
+                    .value_parser(color_parser),
+            )
+            .arg(
+                Arg::new("bar-color")
+                    .help("The color of the bar just above the piano")
+                    .long_help(
+                        "A hex color string describing the color of the bar just above \
+                         the on-screen piano keyboard",
+                    )
+                    .long("bar-color")
+                    .value_parser(color_parser),
+            )
+            .arg(
+                Arg::new("hide-top-pannel")
+                    .long_help(
+                        "Hides the top panel from view when the app opens. It can be un-hidden \
+                        with Ctrl+F",
+                    )
+                    .help("Hide the top panel")
+                    .long("hide-top-pannel")
+                    .action(ArgAction::SetFalse),
+            )
+            .arg(
+                Arg::new("hide-statistics")
+                    .help("Hide the statistics window")
+                    .long_help(
+                        "Hides the statistics window from view when the app opens. It can be \
+                        un-hidden with Ctrl+G",
+                    )
+                    .long("hide-statistics")
+                    .action(ArgAction::SetFalse),
+            )
+            .arg(
+                Arg::new("fullscreen")
+                    .help("Start `wasabi` in fullscreen")
+                    .long_help(
+                        "Starts `wasabi` in fullscreen mode. `wasabi` will use \
+                        borderless fullscreen mode on Linux systems running Wayland, \
+                        and exclusive fullscreen mode for everyone else",
+                    )
+                    .short('f')
+                    .long("fullscreen")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("midi-file")
+                    .value_hint(ValueHint::FilePath)
+                    .help("The MIDI file to immediately begin playing")
+                    .long_help(
+                        "This MIDI file is played immediately after the app's launch. \
+                        This argument is required to use the `--audio-only` option",
+                    ),
+            )
+            .get_matches();
+
+        macro_rules! set {
+            ($one:ident.$two:ident,$value:expr) => {
+                if let Some(value) = matches.get_one($value) {
+                    self.$one.$two = *value;
+                }
+            };
         }
+
+        macro_rules! set_flag {
+            ($one:ident.$two:ident,$value:expr) => {
+                if matches!(matches.value_source($value), Some(ValueSource::CommandLine)) {
+                    if let Some(value) = matches.get_one($value) {
+                        self.$one.$two = *value;
+                    }
+                }
+            };
+        }
+
+        macro_rules! set_owned {
+            ($one:ident.$two:ident,$value:expr,$type:ty) => {
+                if let Some(value) = matches.get_one::<$type>($value) {
+                    self.$one.$two = value.to_owned();
+                }
+            };
+        }
+
+        self.load_midi_file = matches.get_one::<String>("midi-file").map(|f| f.to_owned());
+
+        // Synth settings
+        set!(synth.synth, "synth");
+        set!(synth.buffer_ms, "buffer-ms");
+        set_owned!(synth.sfz_path, "sfz-path", String);
+        set_flag!(synth.limit_layers, "dont-limit-layers");
+        set!(synth.layer_count, "layer-count");
+        set_owned!(synth.vel_ignore, "vel-ignore", RangeInclusive<u8>);
+        set_flag!(synth.fade_out_kill, "fade-out-kill");
+        set_flag!(synth.linear_envelope, "linear-envelope");
+        set_flag!(synth.use_effects, "no-effects");
+
+        // MIDI settings
+        set!(midi.note_speed, "note-speed");
+        set_flag!(midi.random_colors, "random-colors");
+        set_owned!(midi.key_range, "key-range", RangeInclusive<u8>);
+        set!(midi.midi_loading, "midi-loading");
+
+        // Visual settings
+        set_flag!(visual.audio_only, "audio-only");
+        set!(visual.bg_color, "bg-color");
+        set!(visual.bar_color, "bar-color");
+        set_flag!(visual.show_top_pannel, "hide-top-pannel");
+        set_flag!(visual.show_statistics, "hide-statistics");
+        set_flag!(visual.fullscreen, "fullscreen");
+    }
+
+    fn load_and_save_defaults() -> Self {
+        let _ = fs::remove_file(Self::get_config_path());
+        let cfg = Self::default();
+        Self::save_to_file(&cfg);
+        cfg
     }
 
     fn get_config_path() -> String {
         if let Some(base_dirs) = BaseDirs::new() {
             let mut path: PathBuf = base_dirs.config_dir().to_path_buf();
             path.push("wasabi");
-            path.push("wasabi-config.toml");
+            path.push(CONFIG_PATH);
 
             if let Ok(..) = std::fs::create_dir_all(path.parent().unwrap()) {
                 if let Some(path) = path.to_str() {
                     path.to_string()
                 } else {
-                    "wasabi-config.toml".to_string()
+                    CONFIG_PATH.to_string()
                 }
             } else {
-                "wasabi-config.toml".to_string()
+                CONFIG_PATH.to_string()
             }
         } else {
-            "wasabi-config.toml".to_string()
+            CONFIG_PATH.to_string()
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -385,8 +385,13 @@ impl WasabiSettings {
             )
             .arg(
                 Arg::new("buffer-ms")
-                    .help("??????????????")
-                    .long_help("??????????")
+                    .help("The size of the event buffer")
+                    .long_help(
+                        "The amount of time in milliseconds that events \
+                        are held in the buffer before they are played. Making this \
+                        option larger can help MIDI files play in real-time that wouldn't \
+                        otherwise.",
+                    )
                     .short('b')
                     .long("buffer-ms")
                     .value_parser(f64_parser),
@@ -407,15 +412,19 @@ impl WasabiSettings {
             .arg(
                 Arg::new("no-layer-limit")
                     .short('L')
-                    .help("??????????????")
-                    .long_help("??????????")
+                    .help("Disable the voice limiter")
+                    .long_help(
+                        "Allow for the synth to create as many voices as \
+                        needed to play the MIDI file faithfully",
+                    )
                     .long("no-layer-limit")
+                    .conflicts_with("layer-count")
                     .action(ArgAction::SetFalse),
             )
             .arg(
                 Arg::new("layer-count")
-                    .help("??????????????")
-                    .long_help("??????????")
+                    .help("The maximum amount of voice allowed")
+                    .long_help("The maximum amount of voices allowed to play per key per channel")
                     .short('l')
                     .long("layer-count")
                     .value_parser(value_parser!(usize)),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,7 +43,7 @@ fn color_parser(s: &str) -> Result<Color32, String> {
 #[inline(always)]
 fn range_parser(s: &str) -> Result<RangeInclusive<u8>, String> {
     let range = s
-        .split_once(",")
+        .split_once(',')
         .ok_or_else(|| String::from("This argument requires 2 numbers, comma seperated"))?;
 
     Ok(range.0.parse().map_err(|e| format!("{}", e))?

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,8 +3,6 @@ use std::path::PathBuf;
 #[derive(Clone)]
 pub struct WasabiState {
     pub fullscreen: bool,
-    pub panel_visible: bool,
-    pub stats_visible: bool,
     pub settings_visible: bool,
     pub xsynth_settings_visible: bool,
     pub last_midi_file: Option<PathBuf>,
@@ -15,8 +13,6 @@ impl Default for WasabiState {
     fn default() -> Self {
         Self {
             fullscreen: false,
-            panel_visible: true,
-            stats_visible: true,
             settings_visible: false,
             xsynth_settings_visible: false,
             last_midi_file: None,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,22 +1,10 @@
 use std::path::PathBuf;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct WasabiState {
     pub fullscreen: bool,
     pub settings_visible: bool,
     pub xsynth_settings_visible: bool,
     pub last_midi_file: Option<PathBuf>,
     pub last_sfz_file: Option<PathBuf>,
-}
-
-impl Default for WasabiState {
-    fn default() -> Self {
-        Self {
-            fullscreen: false,
-            settings_visible: false,
-            xsynth_settings_visible: false,
-            last_midi_file: None,
-            last_sfz_file: None,
-        }
-    }
 }


### PR DESCRIPTION
## Various UX Improvements
This pull request makes `wasabi` more user friendly in various ways.

## Better config file
- I re-factored the config file to mimic how the Settings window organizes things. This is what the new config file looks like
```toml
[synth]
synth = "xsynth"
buffer_ms = 10.0
sfz_path = "/home/isaacm/CFazKeys/1. CFaz Keys IV - Concert Presets/CFaz Keys IV.sfz"
limit_layers = true
layer_count = 4
fade_out_kill = false
linear_envelope = false
use_effects = true

[synth.vel_ignore]
hi = 0
lo = 0

[midi]
note_speed = 0.25
random_colors = false
midi_loading = "ram"

[midi.key_range]
hi = 0
lo = 127

[visual]
audio_only = false
bg_color = "#1e1e1e"
bar_color = "#910000"
show_top_pannel = true
show_statistics = true
fullscreen = false
```
- There's now a big **Save Settings** button that allows users to make their settings persistent without writing anything to a file manually
![20230413_17h40m36s_grim](https://user-images.githubusercontent.com/57533634/231889152-710840c7-91a7-4e64-9418-2c57a507c630.png)

## Command line options (**Incomplete**)
- `wasabi` settings can now be augmented via the command line. Each option has a short and a long help text, except for the options I don't understand yet (I've already asked @arduano about them on Discord).
```
Usage: wasabi [OPTIONS] [midi-file]

Arguments:
  [midi-file]  The MIDI file to immediately begin playing

Options:
  -S, --synth <synth>                The synthesizer to use
  -b, --buffer-ms <buffer-ms>        ??????????????
  -s, --sfz-path <sfz-path>          The path to an SFZ SoundFont
  -L, --no-layer-limit               ??????????????
  -l, --layer-count <layer-count>    ??????????????
  -v, --vel-ignore <vel-ignore>      The range of note velocities that the synth will discard
  -F, --fade-out-kill                Once a voice is killed, fade it out
  -e, --linear-envelope              ??????????????
  -N, --no-effects                   Disable the synth's effects
  -n, --note-speed <note-speed>      The speed that the notes travel on-screen
  -r, --random-colors                Make each channel a random color
  -k, --key-range <key-range>        The key range of the on-screen piano keyboard
  -m, --midi-loading <midi-loading>  How the MIDI is loaded into `wasabi`
  -a, --audio-only                   Don't open a window, just play the MIDI
  -c, --bg-color <bg-color>          The window background
  -C, --bar-color <bar-color>        The color of the bar just above the piano
  -t, --hide-top-pannel              Hide the top panel
  -T, --hide-statistics              Hide the statistics window
  -f, --fullscreen                   Start `wasabi` in fullscreen
  -h, --help                         Print help (see more with '--help')
  -V, --version                      Print version
```
- I also added a small CLI player with no window and just audio, with keyboard controls
![20230413_18h50m31s_grim](https://user-images.githubusercontent.com/57533634/231899700-4204589d-31cc-48a5-a87c-4d5031255003.png)
This allows `wasabi` to act as an alternative to a command line MIDI player like `timidity++` or `fluidsynth`

## Better panic handling
- By using the `panicui` crate, crashes can now be reported to the user in a way that's easy to debug
![20230413_18h54m06s_grim](https://user-images.githubusercontent.com/57533634/231900244-0ced6329-6b78-4902-ac27-fc98254a5bb5.png)
- I also made it so that for config file errors, instead of resetting the config file, it will show the user where they went wrong and how they can fix it
![20230413_17h39m28s_grim](https://user-images.githubusercontent.com/57533634/231888881-2b567358-252b-4391-9668-5bc797c100a6.png)

## Better file manager
- I've submited this PR Kaydax/egui_file#1 which adds completion for file names and folders. The implementation details of this were inspired by the `thunar` file manager
![2023-04-13 19-08-52](https://user-images.githubusercontent.com/57533634/231902758-f22dfbdf-0517-4edc-9bd5-cc08e20ff619.gif)