### PR TITLE
Config file refactor & command line options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
  "bitflags",
  "jni-sys",
  "ndk-sys 0.3.0",
- "num_enum",
+ "num_enum 0.5.11",
  "thiserror",
 ]
 
@@ -1609,7 +1609,7 @@ dependencies = [
  "bitflags",
  "jni-sys",
  "ndk-sys 0.4.1+23.1.7779620",
- "num_enum",
+ "num_enum 0.5.11",
  "raw-window-handle 0.5.2",
  "thiserror",
 ]
@@ -1787,7 +1787,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -1800,6 +1809,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3096,6 +3117,7 @@ dependencies = [
  "gen-iter 0.3.0",
  "kdmapi",
  "midi-toolkit-rs",
+ "num_enum 0.6.1",
  "palette",
  "rand",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe21446ad43aa56417a767f3e2f3d7c4ca522904de1dd640529a76e9c5c3b33c"
+checksum = "5110f1c78cf582855d895ecd0746b653db010cec6d9f5575293f27934d980a39"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -65,6 +65,55 @@ checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "anstream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -205,9 +254,9 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytemuck"
@@ -226,7 +275,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -260,7 +309,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
- "clap",
+ "clap 3.2.23",
  "heck",
  "indexmap",
  "log",
@@ -322,11 +371,33 @@ checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
+ "strsim",
 ]
 
 [[package]]
@@ -337,6 +408,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "clipboard-win"
@@ -394,6 +471,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colors-transform"
@@ -981,7 +1064,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1204,6 +1287,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,9 +1419,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libloading"
@@ -1346,9 +1441,9 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "lock_api"
@@ -1773,9 +1868,9 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25e9fb15717794fae58ab55c26e044103aad13186fbb625893f9a3bbcc24228"
+checksum = "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4"
 dependencies = [
  "ttf-parser",
 ]
@@ -2097,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2130,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "riff"
@@ -2166,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
 dependencies = [
  "bitflags",
  "errno",
@@ -2258,14 +2353,14 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -2635,9 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2689,7 +2784,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2841,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633"
+checksum = "44dcf002ae3b32cd25400d6df128c5babec3927cd1eb7ce813cfff20eb6c3746"
 
 [[package]]
 name = "unicode-bidi"
@@ -2876,6 +2971,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vec_map"
@@ -2982,6 +3083,7 @@ version = "0.1.0"
 dependencies = [
  "atomic_float",
  "bytemuck",
+ "clap 4.2.4",
  "colors-transform",
  "confy",
  "crossbeam-channel",
@@ -3164,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579cc485bd5ce5bfa0d738e4921dd0b956eca9800be1fd2e5257ebe95bc4617e"
+checksum = "b692165700260bbd40fbc5ff23766c03e339fbaca907aeea5cb77bf0a553ca83"
 dependencies = [
  "core-foundation",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ directories = "4.0.1"
 rustc-hash = "1.1.0"
 atomic_float = "0.1.0"
 egui_file = { git = "https://github.com/Kaydax/egui_file.git", rev = "7ac26fb" }
+clap = "4.2.4"
 
 [profile.dev]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rustc-hash = "1.1.0"
 atomic_float = "0.1.0"
 egui_file = { git = "https://github.com/Kaydax/egui_file.git", rev = "7ac26fb" }
 clap = "4.2.4"
+num_enum = "0.6.1"
 
 [profile.dev]
 opt-level = 2

--- a/src/audio_playback/xsynth.rs
+++ b/src/audio_playback/xsynth.rs
@@ -83,6 +83,5 @@ pub fn convert_to_sf_init(settings: &WasabiSettings) -> SoundfontInitOptions {
 pub fn convert_to_channel_init(settings: &WasabiSettings) -> ChannelInitOptions {
     ChannelInitOptions {
         fade_out_killing: settings.synth.fade_out_kill,
-        ..Default::default()
     }
 }

--- a/src/audio_playback/xsynth.rs
+++ b/src/audio_playback/xsynth.rs
@@ -74,15 +74,15 @@ impl XSynthPlayer {
 
 pub fn convert_to_sf_init(settings: &WasabiSettings) -> SoundfontInitOptions {
     SoundfontInitOptions {
-        linear_release: settings.linear_envelope,
-        use_effects: settings.use_effects,
+        linear_release: settings.synth.linear_envelope,
+        use_effects: settings.synth.use_effects,
         ..Default::default()
     }
 }
 
 pub fn convert_to_channel_init(settings: &WasabiSettings) -> ChannelInitOptions {
     ChannelInitOptions {
-        fade_out_killing: settings.fade_out_kill,
+        fade_out_killing: settings.synth.fade_out_kill,
         ..Default::default()
     }
 }

--- a/src/audio_playback/xsynth.rs
+++ b/src/audio_playback/xsynth.rs
@@ -76,11 +76,13 @@ pub fn convert_to_sf_init(settings: &WasabiSettings) -> SoundfontInitOptions {
     SoundfontInitOptions {
         linear_release: settings.linear_envelope,
         use_effects: settings.use_effects,
+        ..Default::default()
     }
 }
 
 pub fn convert_to_channel_init(settings: &WasabiSettings) -> ChannelInitOptions {
     ChannelInitOptions {
         fade_out_killing: settings.fade_out_kill,
+        ..Default::default()
     }
 }

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     gui::window::{keyboard::GuiKeyboard, scene::GuiRenderScene},
     midi::{InRamMIDIFile, LiveLoadMIDIFile, MIDIFileBase, MIDIFileUnion},
-    settings::WasabiSettings,
+    settings::{MidiLoading, Synth, WasabiSettings},
     state::WasabiState,
     GuiRenderer, GuiState,
 };
@@ -47,28 +47,28 @@ pub struct GuiWasabiWindow {
 
 impl GuiWasabiWindow {
     pub fn new(renderer: &mut GuiRenderer, settings: &mut WasabiSettings) -> GuiWasabiWindow {
-        let synth = match settings.synth {
-            1 => Arc::new(RwLock::new(SimpleTemporaryPlayer::new(
+        let synth = match settings.synth.synth {
+            Synth::Kdmapi => Arc::new(RwLock::new(SimpleTemporaryPlayer::new(
                 AudioPlayerType::Kdmapi,
             ))),
-            _ => {
+            Synth::XSynth => {
                 let synth = Arc::new(RwLock::new(SimpleTemporaryPlayer::new(
                     AudioPlayerType::XSynth {
-                        buffer: settings.buffer_ms,
-                        ignore_range: settings.vel_ignore.clone(),
+                        buffer: settings.synth.buffer_ms,
+                        ignore_range: settings.synth.vel_ignore.clone(),
                         options: convert_to_channel_init(settings),
                     },
                 )));
                 synth
                     .write()
                     .unwrap()
-                    .set_soundfont(&settings.sfz_path, convert_to_sf_init(settings));
+                    .set_soundfont(&settings.synth.sfz_path, convert_to_sf_init(settings));
                 synth
                     .write()
                     .unwrap()
-                    .set_layer_count(match settings.layer_count {
+                    .set_layer_count(match settings.synth.layer_count {
                         0 => None,
-                        _ => Some(settings.layer_count),
+                        _ => Some(settings.synth.layer_count),
                     });
                 synth
             }
@@ -127,17 +127,17 @@ impl GuiWasabiWindow {
         let height = available.height();
         let panel_height = height_prev - height;
         let keyboard_height =
-            (11.6 / settings.key_range.len() as f32 * available.width()).min(height / 2.0);
+            (11.6 / settings.midi.key_range.len() as f32 * available.width()).min(height / 2.0);
         let notes_height = height - keyboard_height;
 
         let key_view = self.keyboard_layout.get_view_for_keys(
-            *settings.key_range.start() as usize,
-            *settings.key_range.end() as usize,
+            *settings.midi.key_range.start() as usize,
+            *settings.midi.key_range.end() as usize,
         );
 
         let no_frame = Frame::default()
             .inner_margin(Margin::same(0.0))
-            .fill(settings.bg_color);
+            .fill(settings.visual.bg_color);
 
         let mut stats = stats::GuiMidiStats::empty();
 
@@ -171,10 +171,10 @@ impl GuiWasabiWindow {
                                         }
                                     }
                                     egui::Key::ArrowUp => {
-                                        settings.note_speed += 0.05;
+                                        settings.midi.note_speed += 0.05;
                                     }
                                     egui::Key::ArrowDown => {
-                                        settings.note_speed -= 0.05;
+                                        settings.midi.note_speed -= 0.05;
                                     }
                                     egui::Key::Space => midi_file.timer_mut().toggle_pause(),
                                     _ => {}
@@ -188,7 +188,7 @@ impl GuiWasabiWindow {
                         ui,
                         &key_view,
                         midi_file,
-                        settings.note_speed,
+                        settings.midi.note_speed,
                     );
                     stats.set_rendered_note_count(result.notes_rendered);
                     render_result_data = Some(result);
@@ -234,7 +234,7 @@ impl GuiWasabiWindow {
                 };
 
                 self.keyboard
-                    .draw(ui, &key_view, &colors, &settings.bar_color);
+                    .draw(ui, &key_view, &colors, &settings.visual.bar_color);
             });
 
         // Render the stats
@@ -275,26 +275,25 @@ impl GuiWasabiWindow {
         self.midi_file = None;
 
         if let Some(midi_path) = midi_path.to_str() {
-            match settings.midi_loading {
-                0 => {
+            match settings.midi.midi_loading {
+                MidiLoading::Ram => {
                     let mut midi_file = MIDIFileUnion::InRam(InRamMIDIFile::load_from_file(
                         midi_path,
                         self.synth.clone(),
-                        settings.random_colors,
+                        settings.midi.random_colors,
                     ));
                     midi_file.timer_mut().play();
                     self.midi_file = Some(midi_file);
                 }
-                1 => {
+                MidiLoading::Live => {
                     let mut midi_file = MIDIFileUnion::Live(LiveLoadMIDIFile::load_from_file(
                         midi_path,
                         self.synth.clone(),
-                        settings.random_colors,
+                        settings.midi.random_colors,
                     ));
                     midi_file.timer_mut().play();
                     self.midi_file = Some(midi_file);
                 }
-                _ => {}
             }
         }
     }

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -116,7 +116,7 @@ impl GuiWasabiWindow {
         }
 
         let height_prev = ctx.available_rect().height();
-        if wasabi_state.panel_visible {
+        if settings.visual.show_top_pannel {
             top_panel::draw_panel(self, settings, wasabi_state, &ctx);
         }
 
@@ -212,10 +212,12 @@ impl GuiWasabiWindow {
                         if *pressed && modifiers.ctrl {
                             match key {
                                 egui::Key::F => {
-                                    wasabi_state.panel_visible = !wasabi_state.panel_visible
+                                    settings.visual.show_top_pannel =
+                                        !settings.visual.show_top_pannel
                                 }
                                 egui::Key::G => {
-                                    wasabi_state.stats_visible = !wasabi_state.stats_visible
+                                    settings.visual.show_statistics =
+                                        !settings.visual.show_statistics;
                                 }
                                 //egui::Key::O => self.open_midi_dialog(wasabi_state),
                                 _ => {}
@@ -238,7 +240,7 @@ impl GuiWasabiWindow {
             });
 
         // Render the stats
-        if wasabi_state.stats_visible {
+        if settings.visual.show_statistics {
             let voice_count = self.synth.read().unwrap().get_voice_count();
             stats.set_voice_count(voice_count);
 

--- a/src/gui/window/settings_window.rs
+++ b/src/gui/window/settings_window.rs
@@ -8,7 +8,7 @@ use crate::{
         AudioPlayerType,
     },
     gui::window::GuiWasabiWindow,
-    settings::WasabiSettings,
+    settings::{MidiLoading, Synth, WasabiSettings},
     state::WasabiState,
 };
 
@@ -38,39 +38,38 @@ pub fn draw_settings(
                 .min_col_width(col_width)
                 .show(ui, |ui| {
                     ui.label("Synth: ");
-                    let synth_prev = settings.synth;
-                    let synth = ["XSynth", "KDMAPI"];
-                    egui::ComboBox::from_id_source("synth_select").show_index(
-                        ui,
-                        &mut settings.synth,
-                        synth.len(),
-                        |i| synth[i].to_owned(),
-                    );
-                    if settings.synth != synth_prev {
-                        match settings.synth {
-                            1 => {
+                    let synth_prev = settings.synth.synth;
+                    egui::ComboBox::from_id_source("synth_select")
+                        .selected_text(settings.synth.synth.as_str())
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(&mut settings.synth.synth, Synth::XSynth, "XSynth");
+                            ui.selectable_value(&mut settings.synth.synth, Synth::Kdmapi, "KDMAPI");
+                        });
+                    if settings.synth.synth != synth_prev {
+                        match settings.synth.synth {
+                            Synth::Kdmapi => {
                                 win.synth
                                     .write()
                                     .unwrap()
                                     .switch_player(AudioPlayerType::Kdmapi);
                             }
-                            _ => {
+                            Synth::XSynth => {
                                 win.synth
                                     .write()
                                     .unwrap()
                                     .switch_player(AudioPlayerType::XSynth {
-                                        buffer: settings.buffer_ms,
-                                        ignore_range: settings.vel_ignore.clone(),
+                                        buffer: settings.synth.buffer_ms,
+                                        ignore_range: settings.synth.vel_ignore.clone(),
                                         options: convert_to_channel_init(settings),
                                     });
                                 win.synth.write().unwrap().set_soundfont(
-                                    &settings.sfz_path,
+                                    &settings.synth.sfz_path,
                                     convert_to_sf_init(settings),
                                 );
                                 win.synth.write().unwrap().set_layer_count(
-                                    match settings.layer_count {
+                                    match settings.synth.layer_count {
                                         0 => None,
-                                        _ => Some(settings.layer_count),
+                                        _ => Some(settings.synth.layer_count),
                                     },
                                 );
                             }
@@ -97,16 +96,19 @@ pub fn draw_settings(
                 .show(ui, |ui| {
                     ui.label("Note speed: ");
                     ui.spacing_mut().slider_width = 150.0;
-                    ui.add(egui::Slider::new(&mut settings.note_speed, 2.0..=0.001));
+                    ui.add(egui::Slider::new(
+                        &mut settings.midi.note_speed,
+                        2.0..=0.001,
+                    ));
                     ui.end_row();
 
                     ui.label("Random Track Colors*: ");
-                    ui.checkbox(&mut settings.random_colors, "");
+                    ui.checkbox(&mut settings.midi.random_colors, "");
                     ui.end_row();
 
                     ui.label("Keyboard Range: ");
-                    let mut firstkey = *settings.key_range.start();
-                    let mut lastkey = *settings.key_range.end();
+                    let mut firstkey = *settings.midi.key_range.start();
+                    let mut lastkey = *settings.midi.key_range.end();
                     ui.horizontal(|ui| {
                         ui.add(
                             egui::DragValue::new(&mut firstkey)
@@ -120,20 +122,27 @@ pub fn draw_settings(
                         );
                     });
                     ui.end_row();
-                    if firstkey != *settings.key_range.start()
-                        || lastkey != *settings.key_range.end()
+                    if firstkey != *settings.midi.key_range.start()
+                        || lastkey != *settings.midi.key_range.end()
                     {
-                        settings.key_range = firstkey..=lastkey;
+                        settings.midi.key_range = firstkey..=lastkey;
                     }
 
                     ui.label("MIDI Loading*: ");
-                    let midi_loading = ["In RAM", "Live"];
-                    egui::ComboBox::from_id_source("midiload_select").show_index(
-                        ui,
-                        &mut settings.midi_loading,
-                        midi_loading.len(),
-                        |i| midi_loading[i].to_owned(),
-                    );
+                    egui::ComboBox::from_id_source("midiload_select")
+                        .selected_text(settings.midi.midi_loading.as_str())
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(
+                                &mut settings.midi.midi_loading,
+                                MidiLoading::Ram,
+                                "In RAM",
+                            );
+                            ui.selectable_value(
+                                &mut settings.midi.midi_loading,
+                                MidiLoading::Live,
+                                "Live",
+                            );
+                        });
                 });
 
             // Visual settings section
@@ -152,11 +161,11 @@ pub fn draw_settings(
                     ui.end_row();
 
                     ui.label("Background Color: ");
-                    ui.color_edit_button_srgba(&mut settings.bg_color);
+                    ui.color_edit_button_srgba(&mut settings.visual.bg_color);
                     ui.end_row();
 
                     ui.label("Bar Color: ");
-                    ui.color_edit_button_srgba(&mut settings.bar_color);
+                    ui.color_edit_button_srgba(&mut settings.visual.bar_color);
                     ui.end_row();
                 });
 

--- a/src/gui/window/top_panel.rs
+++ b/src/gui/window/top_panel.rs
@@ -60,7 +60,8 @@ pub fn draw_panel(
                 ui.horizontal(|ui| {
                     ui.label("Note speed: ");
                     ui.add(
-                        egui::Slider::new(&mut settings.note_speed, 2.0..=0.001).show_value(false),
+                        egui::Slider::new(&mut settings.midi.note_speed, 2.0..=0.001)
+                            .show_value(false),
                     );
                 })
             });

--- a/src/gui/window/xsynth_settings.rs
+++ b/src/gui/window/xsynth_settings.rs
@@ -40,7 +40,7 @@ pub fn draw_xsynth_settings(
                 .show(ui, |ui| {
                     ui.label("Synth Render Buffer (ms)*: ");
                     ui.add(
-                        egui::DragValue::new(&mut settings.buffer_ms)
+                        egui::DragValue::new(&mut settings.synth.buffer_ms)
                             .speed(0.1)
                             .clamp_range(RangeInclusive::new(0.001, 1000.0)),
                     );
@@ -48,7 +48,7 @@ pub fn draw_xsynth_settings(
 
                     ui.label("SFZ Path: ");
                     ui.horizontal(|ui| {
-                        ui.add(egui::TextEdit::singleline(&mut settings.sfz_path));
+                        ui.add(egui::TextEdit::singleline(&mut settings.synth.sfz_path));
 
                         let filter = |path: &std::path::Path| {
                             if let Some(path) = path.to_str() {
@@ -74,51 +74,51 @@ pub fn draw_xsynth_settings(
                             if dialog.show(ctx).selected() {
                                 if let Some(sfz_path) = dialog.path() {
                                     state.last_sfz_file = Some(sfz_path.clone());
-                                    settings.sfz_path = sfz_path.to_str().unwrap_or("").to_owned();
+                                    settings.synth.sfz_path =
+                                        sfz_path.to_str().unwrap_or("").to_owned();
                                 }
                             }
                         }
 
                         if ui.button("Load").clicked() {
-                            win.synth
-                                .write()
-                                .unwrap()
-                                .set_soundfont(&settings.sfz_path, convert_to_sf_init(settings));
+                            win.synth.write().unwrap().set_soundfont(
+                                &settings.synth.sfz_path,
+                                convert_to_sf_init(settings),
+                            );
                         }
                     });
                     ui.end_row();
 
                     ui.label("Limit Layers: ");
-                    let layer_limit_prev = settings.limit_layers;
-                    ui.checkbox(&mut settings.limit_layers, "");
+                    let layer_limit_prev = settings.synth.limit_layers;
+                    ui.checkbox(&mut settings.synth.limit_layers, "");
                     ui.end_row();
 
                     ui.label("Synth Layer Count: ");
-                    let layer_count_prev = settings.layer_count;
-                    ui.add_enabled_ui(settings.limit_layers, |ui| {
+                    let layer_count_prev = settings.synth.layer_count;
+                    ui.add_enabled_ui(settings.synth.limit_layers, |ui| {
                         ui.add(
-                            egui::DragValue::new(&mut settings.layer_count)
+                            egui::DragValue::new(&mut settings.synth.layer_count)
                                 .speed(1)
                                 .clamp_range(RangeInclusive::new(1, 200)),
                         );
                     });
-                    if settings.layer_count != layer_count_prev
-                        || layer_limit_prev != settings.limit_layers
+                    if settings.synth.layer_count != layer_count_prev
+                        || layer_limit_prev != settings.synth.limit_layers
                     {
-                        win.synth
-                            .write()
-                            .unwrap()
-                            .set_layer_count(if settings.limit_layers {
-                                Some(settings.layer_count)
+                        win.synth.write().unwrap().set_layer_count(
+                            if settings.synth.limit_layers {
+                                Some(settings.synth.layer_count)
                             } else {
                                 None
-                            });
+                            },
+                        );
                     }
                     ui.end_row();
 
                     ui.label("Ignore notes with velocities between*: ");
-                    let mut lovel = *settings.vel_ignore.start();
-                    let mut hivel = *settings.vel_ignore.end();
+                    let mut lovel = *settings.synth.vel_ignore.start();
+                    let mut hivel = *settings.synth.vel_ignore.end();
                     ui.horizontal(|ui| {
                         ui.add(
                             egui::DragValue::new(&mut lovel)
@@ -133,9 +133,10 @@ pub fn draw_xsynth_settings(
                         );
                     });
                     ui.end_row();
-                    if lovel != *settings.vel_ignore.start() || hivel != *settings.vel_ignore.end()
+                    if lovel != *settings.synth.vel_ignore.start()
+                        || hivel != *settings.synth.vel_ignore.end()
                     {
-                        settings.vel_ignore = lovel..=hivel;
+                        settings.synth.vel_ignore = lovel..=hivel;
                     }
                 });
 
@@ -149,15 +150,15 @@ pub fn draw_xsynth_settings(
                 .min_col_width(col_width)
                 .show(ui, |ui| {
                     ui.label("Fade out voice when killing it*: ");
-                    ui.checkbox(&mut settings.fade_out_kill, "");
+                    ui.checkbox(&mut settings.synth.fade_out_kill, "");
                     ui.end_row();
 
                     ui.label("Linear release envelope*: ");
-                    ui.checkbox(&mut settings.linear_envelope, "");
+                    ui.checkbox(&mut settings.synth.linear_envelope, "");
                     ui.end_row();
 
                     ui.label("Use Effects*: ");
-                    ui.checkbox(&mut settings.use_effects, "");
+                    ui.checkbox(&mut settings.synth.use_effects, "");
                     ui.end_row();
                 });
 
@@ -169,19 +170,19 @@ pub fn draw_xsynth_settings(
                         .write()
                         .unwrap()
                         .switch_player(AudioPlayerType::XSynth {
-                            buffer: settings.buffer_ms,
-                            ignore_range: settings.vel_ignore.clone(),
+                            buffer: settings.synth.buffer_ms,
+                            ignore_range: settings.synth.vel_ignore.clone(),
                             options: convert_to_channel_init(settings),
                         });
                     win.synth
                         .write()
                         .unwrap()
-                        .set_soundfont(&settings.sfz_path, convert_to_sf_init(settings));
+                        .set_soundfont(&settings.synth.sfz_path, convert_to_sf_init(settings));
                     win.synth
                         .write()
                         .unwrap()
-                        .set_layer_count(if settings.limit_layers {
-                            Some(settings.layer_count)
+                        .set_layer_count(if settings.synth.limit_layers {
+                            Some(settings.synth.layer_count)
                         } else {
                             None
                         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,13 +34,24 @@ pub const WAYLAND_PRESENT_MODE: PresentMode = PresentMode::Mailbox;
 pub fn main() {
     // Winit event loop
     let event_loop = EventLoop::new();
+    let monitor = event_loop
+        .available_monitors()
+        .next()
+        .expect("no monitor found!");
+
+    let mode = monitor.video_modes().next().expect("no mode found");
 
     // Load the settings values
     let mut settings = WasabiSettings::new_or_load();
     let mut wasabi_state = WasabiState::default();
 
     // Create renderer for our scene & ui
-    let mut renderer = Renderer::new(&event_loop, "Wasabi");
+    let mut renderer = Renderer::new(
+        &event_loop,
+        "Wasabi",
+        settings.visual.fullscreen,
+        mode.clone(),
+    );
 
     // Vulkano & Winit & egui integration
     let mut gui = Gui::new(
@@ -59,13 +70,6 @@ pub fn main() {
     };
 
     let mut gui_state = GuiWasabiWindow::new(&mut gui_render_data, &mut settings);
-
-    let monitor = event_loop
-        .available_monitors()
-        .next()
-        .expect("no monitor found!");
-
-    let mode = monitor.video_modes().next().expect("no mode found");
 
     event_loop.run(move |event, _, control_flow| {
         // Update Egui integration so the UI works!

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -38,7 +38,7 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    pub fn new(event_loop: &EventLoop<()>, name: &str) -> Self {
+    pub fn new(event_loop: &EventLoop<()>, name: &str, fullscreen: bool, mode: VideoMode) -> Self {
         // Why
         let library = VulkanLibrary::new().unwrap();
 
@@ -60,6 +60,21 @@ impl Renderer {
 
         // Create rendering surface along with window
         let window = WindowBuilder::new()
+            .with_fullscreen({
+                if fullscreen {
+                    #[cfg(unix)]
+                    let fullscreen = if event_loop.is_wayland() {
+                        Some(Fullscreen::Borderless(None))
+                    } else {
+                        Some(Fullscreen::Exclusive(mode))
+                    };
+                    #[cfg(not(unix))]
+                    let fullscreen = Some(Fullscreen::Exclusive(mode));
+                    fullscreen
+                } else {
+                    None
+                }
+            })
             .with_inner_size(crate::WINDOW_SIZE)
             .with_title(name)
             .build(event_loop)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -42,7 +42,7 @@ fn color_parser(s: &str) -> Result<Color32, String> {
 #[inline(always)]
 fn range_parser(s: &str) -> Result<RangeInclusive<u8>, String> {
     let range = s
-        .split_once(",")
+        .split_once(',')
         .ok_or_else(|| String::from("This argument requires 2 numbers, comma seperated"))?;
 
     Ok(range.0.parse().map_err(|e| format!("{}", e))?

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,160 +1,336 @@
+use clap::{parser::ValueSource, value_parser, Arg, ArgAction, Command, ValueHint};
 use colors_transform::{Color, Rgb};
 use directories::BaseDirs;
 use egui::Color32;
 use serde_derive::{Deserialize, Serialize};
 use std::{
+    fmt::Debug,
     fs,
     io::Write,
     ops::RangeInclusive,
     path::{Path, PathBuf},
+    str::FromStr,
 };
 use xsynth_core::{channel::ChannelInitOptions, soundfont::SoundfontInitOptions};
 use xsynth_realtime::config::XSynthRealtimeConfig;
 
-#[derive(Deserialize, Serialize)]
-struct WasabiConfigFile {
-    note_speed: f64,
-    bg_color: String,
-    bar_color: String,
-    random_colors: bool,
-    sfz_path: String,
-    first_key: u8,
-    last_key: u8,
-    midi_loading: usize,
-    buffer_ms: f64,
-    limit_layers: bool,
-    layer_count: usize,
-    fade_out_kill: bool,
-    linear_envelope: bool,
-    use_effects: bool,
-    vel_ignore_lo: u8,
-    vel_ignore_hi: u8,
-    synth: usize,
+#[inline(always)]
+fn f64_parser(s: &str) -> Result<f64, String> {
+    s.parse().map_err(|e| format!("{}", e))
 }
 
-pub struct WasabiSettings {
-    pub note_speed: f64,
+#[inline(always)]
+fn note_speed(s: &str) -> Result<f64, String> {
+    let num: f64 = f64_parser(s)?;
+    if (0.0001..=2.0).contains(&num) {
+        Ok(2.0001 - num)
+    } else {
+        Err(String::from("Number must be between >0 and 2.0"))
+    }
+}
+
+#[inline(always)]
+fn color_parser(s: &str) -> Result<Color32, String> {
+    let rgb = Rgb::from_hex_str(s).map_err(|e| e.message)?;
+    Ok(Color32::from_rgb(
+        rgb.get_red() as u8,
+        rgb.get_green() as u8,
+        rgb.get_blue() as u8,
+    ))
+}
+
+#[inline(always)]
+fn range_parser(s: &str) -> Result<RangeInclusive<u8>, String> {
+    let range = s
+        .split_once(",")
+        .ok_or_else(|| String::from("This argument requires 2 numbers, comma seperated"))?;
+
+    Ok(range.0.parse().map_err(|e| format!("{}", e))?
+        ..=range.1.parse().map_err(|e| format!("{}", e))?)
+}
+
+mod color32_serde {
+    use colors_transform::Rgb;
+    use egui::Color32;
+    use serde::{de::Visitor, Deserializer, Serializer};
+
+    use super::color_parser;
+
+    pub fn serialize<S>(color: &Color32, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex_color =
+            Rgb::from(color.r() as f32, color.g() as f32, color.b() as f32).to_css_hex_string();
+
+        ser.serialize_str(&hex_color)
+    }
+
+    pub struct ColorVisitor;
+
+    impl<'de> Visitor<'de> for ColorVisitor {
+        type Value = Color32;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("A color encoded as a hex string")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            color_parser(v)
+                .map_err(|e| E::invalid_value(serde::de::Unexpected::Str(v), &e.as_str()))
+        }
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<Color32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        de.deserialize_str(ColorVisitor)
+    }
+}
+
+mod range_serde {
+    use std::ops::RangeInclusive;
+
+    use serde::{
+        de::{self, Visitor},
+        ser::SerializeStruct,
+        Deserializer, Serializer,
+    };
+
+    use serde_derive::Deserialize;
+
+    pub fn serialize<S>(range: &RangeInclusive<u8>, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut ser_struct = ser.serialize_struct("range", 2)?;
+        ser_struct.serialize_field("hi", range.start())?;
+        ser_struct.serialize_field("lo", range.end())?;
+        ser_struct.end()
+    }
+
+    #[derive(Deserialize)]
+    #[serde(field_identifier, rename_all = "lowercase")]
+    enum Field {
+        Hi,
+        Lo,
+    }
+
+    pub struct RangeVisitor;
+
+    impl<'de> Visitor<'de> for RangeVisitor {
+        type Value = RangeInclusive<u8>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("A color encoded as a hex string")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut hi = None;
+            let mut lo = None;
+            while let Some(key) = map.next_key::<Field>()? {
+                match key {
+                    Field::Hi => {
+                        if hi.is_some() {
+                            return Err(de::Error::duplicate_field("hi"));
+                        }
+                        hi = Some(map.next_value::<u8>()?);
+                    }
+                    Field::Lo => {
+                        if lo.is_some() {
+                            return Err(de::Error::duplicate_field("lo"));
+                        }
+                        lo = Some(map.next_value::<u8>()?);
+                    }
+                }
+            }
+
+            let hi = hi.ok_or_else(|| de::Error::missing_field("hi"))?;
+            let lo = lo.ok_or_else(|| de::Error::missing_field("lo"))?;
+
+            Ok(hi..=lo)
+        }
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<RangeInclusive<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        de.deserialize_struct("range", &["hi", "lo"], RangeVisitor)
+    }
+}
+
+#[repr(usize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum MidiLoading {
+    Ram = 0,
+    Live = 1,
+}
+
+impl MidiLoading {
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            MidiLoading::Ram => "In RAM",
+            MidiLoading::Live => "Live",
+        }
+    }
+}
+
+impl FromStr for MidiLoading {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ram" | "RAM" | "Ram" => Ok(MidiLoading::Ram),
+            "live" | "Live" => Ok(MidiLoading::Live),
+            s => Err(format!(
+                "{} was not expected. Expected one of `ram`, or `live`",
+                s
+            )),
+        }
+    }
+}
+
+#[repr(usize)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Synth {
+    XSynth = 0,
+    Kdmapi = 1,
+}
+
+impl Synth {
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Synth::XSynth => "XSynth",
+            Synth::Kdmapi => "KDMAPI",
+        }
+    }
+}
+
+impl FromStr for Synth {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "xsynth" | "XSynth" => Ok(Synth::XSynth),
+            "kdmapi" | "KDMPAI" => Ok(Synth::Kdmapi),
+            s => Err(format!(
+                "{} was not expected. Expected one of `xsynth`, or `kdmapi`",
+                s
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VisualSettings {
+    #[serde(with = "color32_serde")]
     pub bg_color: Color32,
+    #[serde(with = "color32_serde")]
     pub bar_color: Color32,
+    pub show_top_pannel: bool,
+    pub show_statistics: bool,
+    pub fullscreen: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MidiSettings {
+    pub note_speed: f64,
     pub random_colors: bool,
-    pub sfz_path: String,
+    #[serde(with = "range_serde")]
     pub key_range: RangeInclusive<u8>,
-    pub midi_loading: usize,
+    pub midi_loading: MidiLoading,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SynthSettings {
+    pub synth: Synth,
     pub buffer_ms: f64,
+    pub sfz_path: String,
     pub limit_layers: bool,
     pub layer_count: usize,
+    #[serde(with = "range_serde")]
+    pub vel_ignore: RangeInclusive<u8>,
     pub fade_out_kill: bool,
     pub linear_envelope: bool,
     pub use_effects: bool,
-    pub vel_ignore: RangeInclusive<u8>,
-    pub synth: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WasabiSettings {
+    pub synth: SynthSettings,
+    pub midi: MidiSettings,
+    pub visual: VisualSettings,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_midi_file: Option<String>,
 }
 
 impl Default for WasabiSettings {
     fn default() -> Self {
         WasabiSettings {
-            note_speed: 0.25,
-            bg_color: Color32::from_rgb(30, 30, 30),
-            bar_color: Color32::from_rgb(145, 0, 0),
-            random_colors: false,
-            sfz_path: "".to_string(),
-            key_range: 0..=127,
-            midi_loading: 0,
-            buffer_ms: XSynthRealtimeConfig::default().render_window_ms,
-            limit_layers: true,
-            layer_count: 4,
-            fade_out_kill: ChannelInitOptions::default().fade_out_killing,
-            linear_envelope: SoundfontInitOptions::default().linear_release,
-            use_effects: SoundfontInitOptions::default().use_effects,
-            vel_ignore: 0..=0,
-            synth: 0,
+            synth: SynthSettings {
+                synth: Synth::XSynth,
+                buffer_ms: XSynthRealtimeConfig::default().render_window_ms,
+                sfz_path: String::new(),
+                limit_layers: true,
+                layer_count: 4,
+                vel_ignore: 0..=0,
+                fade_out_kill: ChannelInitOptions::default().fade_out_killing,
+                linear_envelope: SoundfontInitOptions::default().linear_release,
+                use_effects: SoundfontInitOptions::default().use_effects,
+            },
+            midi: MidiSettings {
+                note_speed: 0.25,
+                random_colors: false,
+                key_range: 0..=127,
+                midi_loading: MidiLoading::Ram,
+            },
+            visual: VisualSettings {
+                bg_color: Color32::from_rgb(30, 30, 30),
+                bar_color: Color32::from_rgb(145, 0, 0),
+                show_top_pannel: true,
+                show_statistics: true,
+                fullscreen: false,
+            },
+            load_midi_file: None,
         }
     }
 }
 
-static CONFIG_PATH: &str = "wasabi_config.toml";
+static CONFIG_PATH: &str = "wasabi-config.toml";
 
 impl WasabiSettings {
     pub fn new_or_load() -> Self {
         let config_path = Self::get_config_path();
-        if !Path::new(&config_path).exists() {
+        let mut config = if !Path::new(&config_path).exists() {
             Self::load_and_save_defaults()
         } else {
-            match fs::read_to_string(&config_path) {
-                Ok(content) => match toml::from_str::<WasabiConfigFile>(&content) {
-                    Ok(cfg) => {
-                        if let (Ok(bg), Ok(bar)) = (
-                            Rgb::from_hex_str(&cfg.bg_color),
-                            Rgb::from_hex_str(&cfg.bar_color),
-                        ) {
-                            Self {
-                                note_speed: cfg.note_speed,
-                                bg_color: Color32::from_rgb(
-                                    bg.get_red() as u8,
-                                    bg.get_green() as u8,
-                                    bg.get_blue() as u8,
-                                ),
-                                bar_color: Color32::from_rgb(
-                                    bar.get_red() as u8,
-                                    bar.get_green() as u8,
-                                    bar.get_blue() as u8,
-                                ),
-                                random_colors: cfg.random_colors,
-                                sfz_path: cfg.sfz_path,
-                                key_range: cfg.first_key..=cfg.last_key,
-                                midi_loading: cfg.midi_loading,
-                                buffer_ms: cfg.buffer_ms,
-                                limit_layers: cfg.limit_layers,
-                                layer_count: cfg.layer_count,
-                                fade_out_kill: cfg.fade_out_kill,
-                                linear_envelope: cfg.linear_envelope,
-                                use_effects: cfg.use_effects,
-                                vel_ignore: cfg.vel_ignore_lo..=cfg.vel_ignore_hi,
-                                synth: cfg.synth,
-                            }
-                        } else {
-                            Self::load_and_save_defaults()
-                        }
-                    }
-                    Err(..) => Self::load_and_save_defaults(),
-                },
-                Err(..) => Self::load_and_save_defaults(),
+            let config = fs::read_to_string(&config_path).unwrap();
+            if let Ok(config) = toml::from_str(&config) {
+                config
+            } else {
+                Self::load_and_save_defaults()
             }
-        }
+        };
+
+        config.augment_from_args();
+        config
     }
 
     pub fn save_to_file(&self) {
         let config_path = Self::get_config_path();
-        let cfg = WasabiConfigFile {
-            note_speed: self.note_speed,
-            bg_color: Rgb::from(
-                self.bg_color.r() as f32,
-                self.bg_color.g() as f32,
-                self.bg_color.b() as f32,
-            )
-            .to_css_hex_string(),
-            bar_color: Rgb::from(
-                self.bar_color.r() as f32,
-                self.bar_color.g() as f32,
-                self.bar_color.b() as f32,
-            )
-            .to_css_hex_string(),
-            random_colors: self.random_colors,
-            sfz_path: self.sfz_path.clone(),
-            first_key: *self.key_range.start(),
-            last_key: *self.key_range.end(),
-            midi_loading: self.midi_loading,
-            buffer_ms: self.buffer_ms,
-            limit_layers: self.limit_layers,
-            layer_count: self.layer_count,
-            fade_out_kill: self.fade_out_kill,
-            linear_envelope: self.linear_envelope,
-            use_effects: self.use_effects,
-            vel_ignore_lo: *self.vel_ignore.start(),
-            vel_ignore_hi: *self.vel_ignore.end(),
-            synth: self.synth,
-        };
-        let toml: String = toml::to_string(&cfg).unwrap();
+        let toml: String = toml::to_string(&self).unwrap();
         if Path::new(&config_path).exists() {
             fs::remove_file(&config_path).expect("Error deleting old config");
         }
@@ -163,34 +339,299 @@ impl WasabiSettings {
             .expect("Error creating config");
     }
 
-    fn load_and_save_defaults() -> Self {
-        match fs::remove_file(CONFIG_PATH) {
-            Ok(..) => {
-                let cfg = Self::default();
-                Self::save_to_file(&cfg);
-                cfg
-            }
-            Err(..) => Self::default(),
+    fn augment_from_args(&mut self) {
+        let matches = Command::new("wasabi")
+            .version(env!("CARGO_PKG_VERSION"))
+            .author(env!("CARGO_PKG_AUTHORS"))
+            .about(env!("CARGO_PKG_DESCRIPTION"))
+            .arg(
+                Arg::new("synth")
+                    .help("The synthesizer to use")
+                    .long_help(
+                        "The synthesizer that is used to play the MIDI. \
+                        This can either be XSynth (recommended) or KDMAPI. KDMAPI \
+                        only works if you have OmniMidi installed, and are using Windows",
+                    )
+                    .short('S')
+                    .long("synth")
+                    .value_parser(Synth::from_str),
+            )
+            .arg(
+                Arg::new("buffer-ms")
+                    .help("The amount of time events are held in the buffer")
+                    .long_help(
+                        "The amount of time that events are held in the \
+                        buffer before being played. Higher numbers may increase \
+                        performance but also increase latency.",
+                    )
+                    .short('b')
+                    .long("buffer-ms")
+                    .value_parser(f64_parser),
+            )
+            .arg(
+                Arg::new("sfz-path")
+                    .help("The path to an SFZ SoundFont")
+                    .long_help(
+                        "The path to any SFZ soundfont. In audio only mode \
+                        a soundfont must be passed either via the config file, or
+                        this command line option. In the GUI you can set this under \
+                        `Open Synth Settings > SFZ Path`",
+                    )
+                    .short('s')
+                    .long("sfz-path")
+                    .value_hint(ValueHint::FilePath),
+            )
+            .arg(
+                Arg::new("dont-limit-layers")
+                    .help("Do not apply the layer limit to the synth")
+                    .long_help(
+                        "This allows the synth to create as many layers as it \
+                        needs to play the MIDI file faithfully. Only turn this on if your \
+                        MIDI sounds bad, or your computer is running on GFuel",
+                    )
+                    .long("dont-limit-layers")
+                    .action(ArgAction::SetFalse),
+            )
+            .arg(
+                Arg::new("layer-count")
+                    .help("The amount of layers that the synthesizer can create")
+                    .long_help(
+                        "The amount of virtual pianos that the synth can create to \
+                        play your piece. A reasonable number for this value is the number of \
+                        CPU cores your computer has.",
+                    )
+                    .short('l')
+                    .long("layer-count")
+                    .value_parser(value_parser!(usize)),
+            )
+            .arg(
+                Arg::new("vel-ignore")
+                    .help("The range of note velocities that the synth will discard")
+                    .long_help(
+                        "Two numbers, comma seperated, that represent a range of velocities \
+                        that the synth will discard, making notes in the range inaudible.",
+                    )
+                    .short('v')
+                    .long("vel-ignore")
+                    .value_parser(range_parser),
+            )
+            .arg(
+                Arg::new("fade-out-kill")
+                    .help("Once a voice is killed, fade it out")
+                    .long_help(
+                        "Once the synthesizer kills one of it's voices, it will fade it \
+                        out as opposed to simply cutting it off",
+                    )
+                    .short('F')
+                    .long("fade-out-kill")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("linear-envelope")
+                    .help("Adjust the rate of decay on the synth's voices")
+                    .long_help(
+                        "Switch the synth's voice's rate of decay from \
+                        exponential to linear. This may be bring a performance \
+                        improvement on some systems.",
+                    )
+                    .short('L')
+                    .long("linear-envelope")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("no-effects")
+                    .help("Disable the synth's effects")
+                    .long_help(
+                        "Disable the effects that the synthesizer applies to the final audio \
+                        render. These effects include a limiter to keep the audio from clipping, \
+                        and a cutoff",
+                    )
+                    .short('N')
+                    .long("no-effects")
+                    .action(ArgAction::SetFalse),
+            )
+            .arg(
+                Arg::new("note-speed")
+                    .help("The speed that the notes travel on-screen")
+                    .long_help(
+                        "The speed at which the notes will move across the screen. This makes \
+                        the notes physically longer, causing them to move faster on-screen",
+                    )
+                    .short('n')
+                    .long("note-speed")
+                    .value_parser(note_speed),
+            )
+            .arg(
+                Arg::new("random-colors")
+                    .help("Make each channel a random color")
+                    .long_help("This causes each of the note channels to become a random color")
+                    .short('r')
+                    .long("random-colors")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("key-range")
+                    .help("The key range of the on-screen piano keyboard")
+                    .long_help(
+                        "Two numbers, comma seperated, that describe the range \
+                        of keys to be shown on the on-screen piano keyboard, the range must \
+                        be less than 255 and more than 0",
+                    )
+                    .short('k')
+                    .long("key-range")
+                    .value_parser(range_parser),
+            )
+            .arg(
+                Arg::new("midi-loading")
+                    .help("How the MIDI is loaded into `wasabi`")
+                    .long_help(
+                        "The method in which the MIDI file is loaded into `wasabi`, the \
+                        two possible options are `ram`, which loads the MIDI file entirely into \
+                        RAM before beginning playback; and `live` which will read the MIDI file \
+                        as it's being played back. The latter method is for using with systems \
+                        with low memory",
+                    )
+                    .short('m')
+                    .long("midi-loading")
+                    .value_parser(MidiLoading::from_str),
+            )
+            .arg(
+                Arg::new("bg-color")
+                    .help("The window background")
+                    .long_help("A hex color string describing the background color of the window")
+                    .long("bg-color")
+                    .value_parser(color_parser),
+            )
+            .arg(
+                Arg::new("bar-color")
+                    .help("The color of the bar just above the piano")
+                    .long_help(
+                        "A hex color string describing the color of the bar just above \
+                         the on-screen piano keyboard",
+                    )
+                    .long("bar-color")
+                    .value_parser(color_parser),
+            )
+            .arg(
+                Arg::new("hide-top-pannel")
+                    .long_help(
+                        "Hides the top panel from view when the app opens. It can be un-hidden \
+                        with Ctrl+F",
+                    )
+                    .help("Hide the top panel")
+                    .long("hide-top-pannel")
+                    .action(ArgAction::SetFalse),
+            )
+            .arg(
+                Arg::new("hide-statistics")
+                    .help("Hide the statistics window")
+                    .long_help(
+                        "Hides the statistics window from view when the app opens. It can be \
+                        un-hidden with Ctrl+G",
+                    )
+                    .long("hide-statistics")
+                    .action(ArgAction::SetFalse),
+            )
+            .arg(
+                Arg::new("fullscreen")
+                    .help("Start `wasabi` in fullscreen")
+                    .long_help(
+                        "Starts `wasabi` in fullscreen mode. `wasabi` will use \
+                        borderless fullscreen mode on Linux systems running Wayland, \
+                        and exclusive fullscreen mode for everyone else",
+                    )
+                    .short('f')
+                    .long("fullscreen")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("midi-file")
+                    .value_hint(ValueHint::FilePath)
+                    .help("The MIDI file to immediately begin playing")
+                    .long_help(
+                        "This MIDI file is played immediately after the app's launch. \
+                        This argument is required to use the `--audio-only` option",
+                    ),
+            )
+            .get_matches();
+
+        macro_rules! set {
+            ($one:ident.$two:ident,$value:expr) => {
+                if let Some(value) = matches.get_one($value) {
+                    self.$one.$two = *value;
+                }
+            };
         }
+
+        macro_rules! set_flag {
+            ($one:ident.$two:ident,$value:expr) => {
+                if matches!(matches.value_source($value), Some(ValueSource::CommandLine)) {
+                    if let Some(value) = matches.get_one($value) {
+                        self.$one.$two = *value;
+                    }
+                }
+            };
+        }
+
+        macro_rules! set_owned {
+            ($one:ident.$two:ident,$value:expr,$type:ty) => {
+                if let Some(value) = matches.get_one::<$type>($value) {
+                    self.$one.$two = value.to_owned();
+                }
+            };
+        }
+
+        self.load_midi_file = matches.get_one::<String>("midi-file").map(|f| f.to_owned());
+
+        // Synth settings
+        set!(synth.synth, "synth");
+        set!(synth.buffer_ms, "buffer-ms");
+        set_owned!(synth.sfz_path, "sfz-path", String);
+        set_flag!(synth.limit_layers, "dont-limit-layers");
+        set!(synth.layer_count, "layer-count");
+        set_owned!(synth.vel_ignore, "vel-ignore", RangeInclusive<u8>);
+        set_flag!(synth.fade_out_kill, "fade-out-kill");
+        set_flag!(synth.linear_envelope, "linear-envelope");
+        set_flag!(synth.use_effects, "no-effects");
+
+        // MIDI settings
+        set!(midi.note_speed, "note-speed");
+        set_flag!(midi.random_colors, "random-colors");
+        set_owned!(midi.key_range, "key-range", RangeInclusive<u8>);
+        set!(midi.midi_loading, "midi-loading");
+
+        // Visual settings
+        set!(visual.bg_color, "bg-color");
+        set!(visual.bar_color, "bar-color");
+        set_flag!(visual.show_top_pannel, "hide-top-pannel");
+        set_flag!(visual.show_statistics, "hide-statistics");
+        set_flag!(visual.fullscreen, "fullscreen");
+    }
+
+    fn load_and_save_defaults() -> Self {
+        let _ = fs::remove_file(Self::get_config_path());
+        let cfg = Self::default();
+        Self::save_to_file(&cfg);
+        cfg
     }
 
     fn get_config_path() -> String {
         if let Some(base_dirs) = BaseDirs::new() {
             let mut path: PathBuf = base_dirs.config_dir().to_path_buf();
             path.push("wasabi");
-            path.push("wasabi-config.toml");
+            path.push(CONFIG_PATH);
 
             if let Ok(..) = std::fs::create_dir_all(path.parent().unwrap()) {
                 if let Some(path) = path.to_str() {
                     path.to_string()
                 } else {
-                    "wasabi-config.toml".to_string()
+                    CONFIG_PATH.to_string()
                 }
             } else {
-                "wasabi-config.toml".to_string()
+                CONFIG_PATH.to_string()
             }
         } else {
-            "wasabi-config.toml".to_string()
+            CONFIG_PATH.to_string()
         }
     }
 }

--- a/src/settings/migrations.rs
+++ b/src/settings/migrations.rs
@@ -29,7 +29,7 @@ pub struct WasabiConfigFileV0 {
 impl WasabiConfigFileV0 {
     pub fn migrate() -> Result<WasabiSettings, toml::de::Error> {
         let config_path = WasabiSettings::get_config_path();
-        let content = fs::read_to_string(&config_path).unwrap_or_default();
+        let content = fs::read_to_string(config_path).unwrap_or_default();
         let cfg = toml::from_str::<WasabiConfigFileV0>(&content)?;
         if let (Ok(bg), Ok(bar)) = (
             Rgb::from_hex_str(&cfg.bg_color),

--- a/src/settings/migrations.rs
+++ b/src/settings/migrations.rs
@@ -1,0 +1,77 @@
+use colors_transform::{Color, Rgb};
+use egui::Color32;
+use serde_derive::Deserialize;
+use std::fs;
+
+use super::{MidiLoading, MidiSettings, Synth, SynthSettings, VisualSettings, WasabiSettings};
+
+#[derive(Deserialize)]
+pub struct WasabiConfigFileV0 {
+    note_speed: f64,
+    bg_color: String,
+    bar_color: String,
+    random_colors: bool,
+    sfz_path: String,
+    first_key: u8,
+    last_key: u8,
+    midi_loading: usize,
+    buffer_ms: f64,
+    limit_layers: bool,
+    layer_count: usize,
+    fade_out_kill: bool,
+    linear_envelope: bool,
+    use_effects: bool,
+    vel_ignore_lo: u8,
+    vel_ignore_hi: u8,
+    synth: usize,
+}
+
+impl WasabiConfigFileV0 {
+    pub fn migrate() -> Result<WasabiSettings, toml::de::Error> {
+        let config_path = WasabiSettings::get_config_path();
+        let content = fs::read_to_string(&config_path).unwrap_or_default();
+        let cfg = toml::from_str::<WasabiConfigFileV0>(&content)?;
+        if let (Ok(bg), Ok(bar)) = (
+            Rgb::from_hex_str(&cfg.bg_color),
+            Rgb::from_hex_str(&cfg.bar_color),
+        ) {
+            Ok(WasabiSettings {
+                synth: SynthSettings {
+                    synth: Synth::from(cfg.synth),
+                    buffer_ms: cfg.buffer_ms,
+                    limit_layers: cfg.limit_layers,
+                    layer_count: cfg.layer_count,
+                    fade_out_kill: cfg.fade_out_kill,
+                    linear_envelope: cfg.linear_envelope,
+                    use_effects: cfg.use_effects,
+                    sfz_path: cfg.sfz_path,
+                    vel_ignore: cfg.vel_ignore_lo..=cfg.vel_ignore_hi,
+                },
+                midi: MidiSettings {
+                    note_speed: cfg.note_speed,
+                    random_colors: cfg.random_colors,
+                    key_range: cfg.first_key..=cfg.last_key,
+                    midi_loading: MidiLoading::from(cfg.midi_loading),
+                },
+                visual: VisualSettings {
+                    bg_color: Color32::from_rgb(
+                        bg.get_red() as u8,
+                        bg.get_green() as u8,
+                        bg.get_blue() as u8,
+                    ),
+                    bar_color: Color32::from_rgb(
+                        bar.get_red() as u8,
+                        bar.get_green() as u8,
+                        bar.get_blue() as u8,
+                    ),
+                    show_top_pannel: true,
+                    show_statistics: true,
+                    fullscreen: false,
+                },
+                load_midi_file: None,
+            })
+        } else {
+            Ok(WasabiSettings::default())
+        }
+    }
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -194,8 +194,8 @@ impl FromStr for MidiLoading {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "ram" | "RAM" | "Ram" => Ok(MidiLoading::Ram),
-            "live" | "Live" => Ok(MidiLoading::Live),
+            "ram" => Ok(MidiLoading::Ram),
+            "live" => Ok(MidiLoading::Live),
             s => Err(format!(
                 "{} was not expected. Expected one of `ram`, or `live`",
                 s
@@ -228,8 +228,8 @@ impl FromStr for Synth {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "xsynth" | "XSynth" => Ok(Synth::XSynth),
-            "kdmapi" | "KDMPAI" => Ok(Synth::Kdmapi),
+            "xsynth" => Ok(Synth::XSynth),
+            "kdmapi" => Ok(Synth::Kdmapi),
             s => Err(format!(
                 "{} was not expected. Expected one of `xsynth`, or `kdmapi`",
                 s
@@ -313,8 +313,11 @@ impl Default for SynthSettings {
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct WasabiSettings {
+    #[serde(default)]
     pub synth: SynthSettings,
+    #[serde(default)]
     pub midi: MidiSettings,
+    #[serde(default)]
     pub visual: VisualSettings,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub load_midi_file: Option<String>,
@@ -459,10 +462,10 @@ impl WasabiSettings {
             )
             .arg(
                 Arg::new("no-effects")
-                    .help("Disable the synth's effects")
+                    .help("Disables the soundfont's effects")
                     .long_help(
-                        "Disable the effects that the synthesizer applies to the final audio \
-                        render. Currently this disables a high/low pass filter",
+                        "Disables soundfont audio effects. \
+                        This may improve the performance.",
                     )
                     .short('N')
                     .long("no-effects")

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -239,6 +239,7 @@ impl FromStr for Synth {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct VisualSettings {
     #[serde(with = "color32_serde")]
     pub bg_color: Color32,
@@ -262,6 +263,7 @@ impl Default for VisualSettings {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct MidiSettings {
     pub note_speed: f64,
     pub random_colors: bool,
@@ -282,6 +284,7 @@ impl Default for MidiSettings {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct SynthSettings {
     pub synth: Synth,
     pub buffer_ms: f64,
@@ -312,12 +315,10 @@ impl Default for SynthSettings {
 }
 
 #[derive(Debug, Deserialize, Serialize, Default)]
+#[serde(default)]
 pub struct WasabiSettings {
-    #[serde(default)]
     pub synth: SynthSettings,
-    #[serde(default)]
     pub midi: MidiSettings,
-    #[serde(default)]
     pub visual: VisualSettings,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub load_midi_file: Option<String>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,8 +3,6 @@ use std::path::PathBuf;
 #[derive(Clone)]
 pub struct WasabiState {
     pub fullscreen: bool,
-    pub panel_visible: bool,
-    pub stats_visible: bool,
     pub settings_visible: bool,
     pub xsynth_settings_visible: bool,
     pub last_midi_file: Option<PathBuf>,
@@ -15,8 +13,6 @@ impl Default for WasabiState {
     fn default() -> Self {
         Self {
             fullscreen: false,
-            panel_visible: true,
-            stats_visible: true,
             settings_visible: false,
             xsynth_settings_visible: false,
             last_midi_file: None,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,22 +1,10 @@
 use std::path::PathBuf;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct WasabiState {
     pub fullscreen: bool,
     pub settings_visible: bool,
     pub xsynth_settings_visible: bool,
     pub last_midi_file: Option<PathBuf>,
     pub last_sfz_file: Option<PathBuf>,
-}
-
-impl Default for WasabiState {
-    fn default() -> Self {
-        Self {
-            fullscreen: false,
-            settings_visible: false,
-            xsynth_settings_visible: false,
-            last_midi_file: None,
-            last_sfz_file: None,
-        }
-    }
 }


### PR DESCRIPTION
The config file and the command line options are highly integrated so I included both in this PR. This PR makes the config file mimic the layout of the settings menu in the actual GUI

These are the default options
```toml
[synth]
synth = "xsynth"
buffer_ms = 10.0
sfz_path = ""
limit_layers = true
layer_count = 4
fade_out_kill = false
linear_envelope = false
use_effects = true

[synth.vel_ignore]
hi = 0
lo = 0

[midi]
note_speed = 0.25
random_colors = false
midi_loading = "ram"

[midi.key_range]
hi = 0
lo = 127

[visual]
audio_only = false
bg_color = "#1e1e1e"
bar_color = "#910000"
show_top_pannel = true
show_statistics = true
fullscreen = false
```
There are also command line options, each option containing a short and long help text. This is the short help
```
Usage: wasabi [OPTIONS] [midi-file]

Arguments:
  [midi-file]  The MIDI file to immediately begin playing

Options:
  -S, --synth <synth>                The synthesizer to use
  -b, --buffer-ms <buffer-ms>        The amount of time events are held in the buffer
  -s, --sfz-path <sfz-path>          The path to an SFZ SoundFont
      --dont-limit-layers            Do not apply the layer limit to the synth
  -l, --layer-count <layer-count>    The amount of layers that the synthesizer can create
  -v, --vel-ignore <vel-ignore>      The range of note velocities that the synth will discard
  -F, --fade-out-kill                Once a voice is killed, fade it out
  -L, --linear-envelope              Adjust the rate of decay on the synth's voices
  -N, --no-effects                   Disable the synth's effects
  -n, --note-speed <note-speed>      The speed that the notes travel on-screen
  -r, --random-colors                Make each channel a random color
  -k, --key-range <key-range>        The key range of the on-screen piano keyboard
  -m, --midi-loading <midi-loading>  How the MIDI is loaded into `wasabi`
      --bg-color <bg-color>          The window background
      --bar-color <bar-color>        The color of the bar just above the piano
      --hide-top-pannel              Hide the top panel
      --hide-statistics              Hide the statistics window
  -f, --fullscreen                   Start `wasabi` in fullscreen
  -h, --help                         Print help (see more with '--help')
  -V, --version                      Print version
```
This is the long help
```
Usage: wasabi [OPTIONS] [midi-file]

Arguments:
  [midi-file]
          This MIDI file is played immediately after the app's launch. This argument is required to use the `--audio-only` option

Options:
  -S, --synth <synth>
          The synthesizer that is used to play the MIDI. This can either be XSynth (recommended) or KDMAPI. KDMAPI only works if you have OmniMidi installed, and are using Windows

  -b, --buffer-ms <buffer-ms>
          The amount of time that events are held in the buffer before being played. Higher numbers may increase performance but also increase latency.

  -s, --sfz-path <sfz-path>
          The path to any SFZ soundfont. In audio only mode a soundfont must be passed either via the config file, or
                                  this command line option. In the GUI you can set this under `Open Synth Settings > SFZ Path`

      --dont-limit-layers
          This allows the synth to create as many layers as it needs to play the MIDI file faithfully. Only turn this on if your MIDI sounds bad, or your computer is running on GFuel

  -l, --layer-count <layer-count>
          The amount of virtual pianos that the synth can create to play your piece. A reasonable number for this value is the number of CPU cores your computer has.

  -v, --vel-ignore <vel-ignore>
          Two numbers, comma seperated, that represent a range of velocities that the synth will discard, making notes in the range inaudible.

  -F, --fade-out-kill
          Once the synthesizer kills one of it's voices, it will fade it out as opposed to simply cutting it off

  -L, --linear-envelope
          Switch the synth's voice's rate of decay from exponential to linear. This may be bring a performance improvement on some systems.

  -N, --no-effects
          Disable the effects that the synthesizer applies to the final audio render. These effects include a limiter to keep the audio from clipping, and a cutoff

  -n, --note-speed <note-speed>
          The speed at which the notes will move across the screen. This makes the notes physically longer, causing them to move faster on-screen

  -r, --random-colors
          This causes each of the note channels to become a random color

  -k, --key-range <key-range>
          Two numbers, comma seperated, that describe the range of keys to be shown on the on-screen piano keyboard, the range must be less than 255 and more than 0

  -m, --midi-loading <midi-loading>
          The method in which the MIDI file is loaded into `wasabi`, the two possible options are `ram`, which loads the MIDI file entirely into RAM before beginning playback; and `live` which will read the MIDI file as it's being played back. The latter method is for using with systems with low memory

      --bg-color <bg-color>
          A hex color string describing the background color of the window

      --bar-color <bar-color>
          A hex color string describing the color of the bar just above the on-screen piano keyboard

      --hide-top-pannel
          Hides the top panel from view when the app opens. It can be un-hidden with Ctrl+F

      --hide-statistics
          Hides the statistics window from view when the app opens. It can be un-hidden with Ctrl+G

  -f, --fullscreen
          Starts `wasabi` in fullscreen mode. `wasabi` will use borderless fullscreen mode on Linux systems running Wayland, and exclusive fullscreen mode for everyone else

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```