### PR TITLE
Fix cake notes when zoomed in

### DIFF
--- a/src/midi/cake/mod.rs
+++ b/src/midi/cake/mod.rs
@@ -49,7 +49,7 @@ impl CakeMIDIFile {
         player: Arc<RwLock<SimpleTemporaryPlayer>>,
         _random_colors: bool,
     ) -> Self {
-        let ticks_per_second = 1000;
+        let ticks_per_second = 10000;
 
         let (file, signature) = open_file_and_signature(path);
         let midi = TKMIDIFile::open_from_stream(file, None).unwrap();


### PR DESCRIPTION
Basically cake had an issue where it's minimum note size was too big, causing notes to look wildly different compared to In ram loading. The downside: we can now only have 59 hour long midis, which I really don't think matters in any capacity