### PR TITLE
Revert PR #44, Fixing the linux workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,46 +3,46 @@ name: Build
 on:
   push:
     tags:
-    - 'v*'
+      - "v*"
 
 jobs:
-  # build-linux:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       target:
-  #         - name: x86_64-unknown-linux-gnu
-  #           arch: x64
-  #         # - name: x86_64-unknown-linux-musl
-  #         #   arch: x64-musl
-  #         - name: aarch64-unknown-linux-gnu
-  #           arch: arm64
-  #         # - name: aarch64-unknown-linux-musl
-  #         #   arch: arm64-musl
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - name: x86_64-unknown-linux-gnu
+            arch: x64
+          # - name: x86_64-unknown-linux-musl
+          #   arch: x64-musl
+          - name: aarch64-unknown-linux-gnu
+            arch: arm64
+          # - name: aarch64-unknown-linux-musl
+          #   arch: arm64-musl
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-  #     - name: Install Rust toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: nightly
-  #         target: ${{ matrix.target.name }}
-  #         override: true
-  #         profile: minimal
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: ${{ matrix.target.name }}
+          override: true
+          profile: minimal
 
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         use-cross: true
-  #         command: build
-  #         args: --release --target=${{ matrix.target.name }}
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target=${{ matrix.target.name }}
 
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: "wasabi-linux-${{ matrix.target.arch }}"
-  #         path: "target/${{ matrix.target.name }}/release/wasabi"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: "wasabi-linux-${{ matrix.target.arch }}"
+          path: "target/${{ matrix.target.name }}/release/wasabi"
 
   build-macos:
     runs-on: macos-latest
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     needs:
-      # - build-linux
+      - build-linux
       - build-macos
       - build-windows
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "251e0b7d90e33e0ba930891a505a9a35ece37b2dd37a14f3ffc306c13b980009"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "atomic_float"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "calloop"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +410,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1022,6 +1054,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ff856cb3386dae1703a920f803abafcc580e9b5f711ca62ed1620c25b51ff2"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "gen-iter"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,10 +1129,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771437bf1de2c1c0b496c11505bdf748e26066bbe942dfc8f614c9460f6d7722"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
 
 [[package]]
 name = "half"
@@ -1865,6 +1979,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2335,29 @@ dependencies = [
  "svgtypes",
  "tiny-skia",
  "usvg",
+]
+
+[[package]]
+name = "rfd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241a0deb168c88050d872294f7b3106c1dfa8740942bcc97bc91b98e97b5c501"
+dependencies = [
+ "block",
+ "dispatch",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2752,6 +2901,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af52f9402f94aac4948a2518b43359be8d9ce6cd9efc1c4de3b2f7b7e897d6"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+
+[[package]]
 name = "tempfile"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,6 +3202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,6 +3338,7 @@ dependencies = [
  "rand",
  "rayon",
  "resvg",
+ "rfd",
  "rustc-hash",
  "serde",
  "serde_derive",
@@ -3207,6 +3382,18 @@ dependencies = [
  "quote",
  "syn 2.0.22",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,18 +189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atk-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251e0b7d90e33e0ba930891a505a9a35ece37b2dd37a14f3ffc306c13b980009"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
 name = "atomic_float"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,16 +334,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
-name = "cairo-sys-rs"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
-dependencies = [
- "libc",
- "system-deps",
-]
-
-[[package]]
 name = "calloop"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,16 +388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3"
-dependencies = [
- "smallvec",
- "target-lexicon",
 ]
 
 [[package]]
@@ -1054,36 +1022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
-name = "gdk-pixbuf-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
-dependencies = [
- "gio-sys",
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gdk-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ff856cb3386dae1703a920f803abafcc580e9b5f711ca62ed1620c25b51ff2"
-dependencies = [
- "cairo-sys-rs",
- "gdk-pixbuf-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
- "libc",
- "pango-sys",
- "pkg-config",
- "system-deps",
-]
-
-[[package]]
 name = "gen-iter"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,62 +1067,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gio-sys"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
- "winapi",
-]
-
-[[package]]
-name = "glib-sys"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
-dependencies = [
- "libc",
- "system-deps",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "gobject-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
-dependencies = [
- "glib-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gtk-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771437bf1de2c1c0b496c11505bdf748e26066bbe942dfc8f614c9460f6d7722"
-dependencies = [
- "atk-sys",
- "cairo-sys-rs",
- "gdk-pixbuf-sys",
- "gdk-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
- "libc",
- "pango-sys",
- "system-deps",
-]
 
 [[package]]
 name = "half"
@@ -1979,18 +1865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pango-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,29 +2209,6 @@ dependencies = [
  "svgtypes",
  "tiny-skia",
  "usvg",
-]
-
-[[package]]
-name = "rfd"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241a0deb168c88050d872294f7b3106c1dfa8740942bcc97bc91b98e97b5c501"
-dependencies = [
- "block",
- "dispatch",
- "glib-sys",
- "gobject-sys",
- "gtk-sys",
- "js-sys",
- "log",
- "objc",
- "objc-foundation",
- "objc_id",
- "raw-window-handle",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2901,25 +2752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-deps"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af52f9402f94aac4948a2518b43359be8d9ce6cd9efc1c4de3b2f7b7e897d6"
-dependencies = [
- "cfg-expr",
- "heck",
- "pkg-config",
- "toml 0.8.2",
- "version-compare",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
-
-[[package]]
 name = "tempfile"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,12 +3034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
-name = "version-compare"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,7 +3164,6 @@ dependencies = [
  "rand",
  "rayon",
  "resvg",
- "rfd",
  "rustc-hash",
  "serde",
  "serde_derive",
@@ -3382,18 +3207,6 @@ dependencies = [
  "quote",
  "syn 2.0.22",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ egui_file = { git = "https://github.com/StratusFearMe21/egui_file.git", rev = "a
 ico = { git = "https://github.com/StratusFearMe21/rust-ico", branch = "patch-1" }
 clap = "4.2.4"
 num_enum = "0.7.0"
-rfd = "0.12.0"
 
 [profile.dev]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ ico = { git = "https://github.com/StratusFearMe21/rust-ico", branch = "patch-1" 
 clap = "4.2.4"
 num_enum = "0.7.0"
 
+[target.'cfg(windows)'.dependencies]
+rfd = "0.12.0"
+
 [profile.dev]
 opt-level = 2
 

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -29,7 +29,6 @@ use crate::{
 };
 
 use egui_file::FileDialog as EFileDialog;
-use rfd::FileDialog as RFileDialog;
 
 pub struct WasabiFileDialogs {
     midi_file_dialog: Option<EFileDialog>,
@@ -255,31 +254,21 @@ impl GuiWasabiWindow {
     }
 
     pub fn open_midi_dialog(&mut self, settings: &mut WasabiSettings, state: &mut WasabiState) {
-        if cfg!(target_os = "windows") {
-            // If windows, just use the native dialog
-            let midi_path = RFileDialog::new().add_filter("mid", &["mid"]).pick_file();
-
-            if let Some(midi_path) = midi_path {
-                state.last_midi_file = Some(midi_path.clone());
-                self.load_midi(settings, midi_path);
+        fn filter(path: &std::path::Path) -> bool {
+            if let Some(path) = path.to_str() {
+                path.ends_with(".mid")
+            } else {
+                false
             }
-        } else {
-            fn filter(path: &std::path::Path) -> bool {
-                if let Some(path) = path.to_str() {
-                    path.ends_with(".mid")
-                } else {
-                    false
-                }
-            }
-
-            let mut dialog = EFileDialog::open_file(state.last_midi_file.clone(), Some(filter))
-                .show_rename(true)
-                .show_new_folder(true)
-                .resizable(true);
-
-            dialog.open();
-            self.file_dialogs.midi_file_dialog = Some(dialog);
         }
+
+        let mut dialog = EFileDialog::open_file(state.last_midi_file.clone(), Some(filter))
+            .show_rename(true)
+            .show_new_folder(true)
+            .resizable(true);
+
+        dialog.open();
+        self.file_dialogs.midi_file_dialog = Some(dialog);
     }
 
     pub fn load_midi(&mut self, settings: &mut WasabiSettings, midi_path: PathBuf) {

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -253,7 +253,7 @@ impl GuiWasabiWindow {
         }
     }
 
-    pub fn open_midi_dialog(&mut self, settings: &mut WasabiSettings, state: &mut WasabiState) {
+    pub fn open_midi_dialog(&mut self, _settings: &mut WasabiSettings, state: &mut WasabiState) {
         fn filter(path: &std::path::Path) -> bool {
             if let Some(path) = path.to_str() {
                 path.ends_with(".mid")

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -28,11 +28,11 @@ use crate::{
     GuiRenderer, GuiState,
 };
 
-use egui_file::FileDialog as EFileDialog;
+use egui_file::FileDialog;
 
 pub struct WasabiFileDialogs {
-    midi_file_dialog: Option<EFileDialog>,
-    sf_file_dialog: Option<EFileDialog>,
+    midi_file_dialog: Option<FileDialog>,
+    sf_file_dialog: Option<FileDialog>,
 }
 
 pub struct GuiWasabiWindow {
@@ -253,22 +253,40 @@ impl GuiWasabiWindow {
         }
     }
 
-    pub fn open_midi_dialog(&mut self, _settings: &mut WasabiSettings, state: &mut WasabiState) {
-        fn filter(path: &std::path::Path) -> bool {
-            if let Some(path) = path.to_str() {
-                path.ends_with(".mid")
-            } else {
-                false
+    #[allow(unused_variables)]
+    pub fn open_midi_dialog(&mut self, settings: &mut WasabiSettings, state: &mut WasabiState) {
+        // TODO: Make this cleaner
+        #[cfg(target_os = "windows")]
+        {
+            // If windows, just use the native dialog
+            let midi_path = rfd::FileDialog::new()
+                .add_filter("mid", &["mid"])
+                .pick_file();
+
+            if let Some(midi_path) = midi_path {
+                state.last_midi_file = Some(midi_path.clone());
+                self.load_midi(settings, midi_path);
             }
         }
 
-        let mut dialog = EFileDialog::open_file(state.last_midi_file.clone(), Some(filter))
-            .show_rename(true)
-            .show_new_folder(true)
-            .resizable(true);
+        #[cfg(not(target_os = "windows"))]
+        {
+            fn filter(path: &std::path::Path) -> bool {
+                if let Some(path) = path.to_str() {
+                    path.ends_with(".mid")
+                } else {
+                    false
+                }
+            }
 
-        dialog.open();
-        self.file_dialogs.midi_file_dialog = Some(dialog);
+            let mut dialog = FileDialog::open_file(state.last_midi_file.clone(), Some(filter))
+                .show_rename(true)
+                .show_new_folder(true)
+                .resizable(true);
+
+            dialog.open();
+            self.file_dialogs.midi_file_dialog = Some(dialog);
+        }
     }
 
     pub fn load_midi(&mut self, settings: &mut WasabiSettings, midi_path: PathBuf) {

--- a/src/gui/window/xsynth_settings.rs
+++ b/src/gui/window/xsynth_settings.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 
 use egui_file::FileDialog as EFileDialog;
-use rfd::FileDialog as RFileDialog;
 
 pub fn draw_xsynth_settings(
     win: &mut GuiWasabiWindow,
@@ -60,28 +59,14 @@ pub fn draw_xsynth_settings(
                         }
 
                         if ui.button("Browse...").clicked() {
-                            if cfg!(target_os = "windows") {
-                                // If windows, just use the native dialog
-                                let sfz_path =
-                                    RFileDialog::new().add_filter("sfz", &["sfz"]).pick_file();
-
-                                if let Some(sfz_path) = sfz_path {
-                                    if let Ok(path) = sfz_path.into_os_string().into_string() {
-                                        settings.synth.sfz_path = path;
-                                    }
-                                }
-                            } else {
-                                let mut dialog = EFileDialog::open_file(
-                                    state.last_sfz_file.clone(),
-                                    Some(filter),
-                                )
-                                .show_rename(false)
-                                .show_new_folder(false)
-                                .resizable(true)
-                                .anchor(egui::Align2::CENTER_TOP, egui::Vec2::new(0.0, 10.0));
-                                dialog.open();
-                                win.file_dialogs.sf_file_dialog = Some(dialog);
-                            }
+                            let mut dialog =
+                                EFileDialog::open_file(state.last_sfz_file.clone(), Some(filter))
+                                    .show_rename(false)
+                                    .show_new_folder(false)
+                                    .resizable(true)
+                                    .anchor(egui::Align2::CENTER_TOP, egui::Vec2::new(0.0, 10.0));
+                            dialog.open();
+                            win.file_dialogs.sf_file_dialog = Some(dialog);
                         }
 
                         if let Some(dialog) = &mut win.file_dialogs.sf_file_dialog {

--- a/src/gui/window/xsynth_settings.rs
+++ b/src/gui/window/xsynth_settings.rs
@@ -12,7 +12,7 @@ use crate::{
     state::WasabiState,
 };
 
-use egui_file::FileDialog as EFileDialog;
+use egui_file::FileDialog;
 
 pub fn draw_xsynth_settings(
     win: &mut GuiWasabiWindow,
@@ -59,14 +59,34 @@ pub fn draw_xsynth_settings(
                         }
 
                         if ui.button("Browse...").clicked() {
-                            let mut dialog =
-                                EFileDialog::open_file(state.last_sfz_file.clone(), Some(filter))
-                                    .show_rename(false)
-                                    .show_new_folder(false)
-                                    .resizable(true)
-                                    .anchor(egui::Align2::CENTER_TOP, egui::Vec2::new(0.0, 10.0));
-                            dialog.open();
-                            win.file_dialogs.sf_file_dialog = Some(dialog);
+                            // TODO: Make this cleaner
+                            #[cfg(target_os = "windows")]
+                            {
+                                // If windows, just use the native dialog
+                                let sfz_path = rfd::FileDialog::new()
+                                    .add_filter("sfz", &["sfz"])
+                                    .pick_file();
+
+                                if let Some(sfz_path) = sfz_path {
+                                    if let Ok(path) = sfz_path.into_os_string().into_string() {
+                                        settings.synth.sfz_path = path;
+                                    }
+                                }
+                            }
+
+                            #[cfg(not(target_os = "windows"))]
+                            {
+                                let mut dialog = FileDialog::open_file(
+                                    state.last_sfz_file.clone(),
+                                    Some(filter),
+                                )
+                                .show_rename(false)
+                                .show_new_folder(false)
+                                .resizable(true)
+                                .anchor(egui::Align2::CENTER_TOP, egui::Vec2::new(0.0, 10.0));
+                                dialog.open();
+                                win.file_dialogs.sf_file_dialog = Some(dialog);
+                            }
                         }
 
                         if let Some(dialog) = &mut win.file_dialogs.sf_file_dialog {


### PR DESCRIPTION
PR #44 is a horrible solution to "making file browsing less shit" for windows users. Focus should to instead improve the already included egui file dialog we were already using. This also fixes the issue with the linux workflow not building due to the fact RFD has a hard dep for GTK, causing linux builds to fail on github due to an outdated glib, even though we are not even using RFD on linux to start with