### PR TITLE
Make cake the default parser

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -280,7 +280,7 @@ impl Default for MidiSettings {
             note_speed: 0.25,
             random_colors: false,
             key_range: 0..=127,
-            midi_loading: MidiLoading::Ram,
+            midi_loading: MidiLoading::Cake,
         }
     }
 }


### PR DESCRIPTION
This just makes Cake the default parser. The only reason is its better to put the best foot forward when people download the player and use it, as not many know about cake and its not really mentioned anywhere